### PR TITLE
feat(header): enlarge & center mobile logo (220/215)

### DIFF
--- a/estilos-header2.css
+++ b/estilos-header2.css
@@ -63,7 +63,7 @@ body {
 }
 .kpem-header-mobile {
   width: 100%;
-  height: 64px;
+  height: 68px;
   padding: 4px 16px;
   background: #fff;
   box-sizing: border-box;
@@ -86,7 +86,7 @@ body {
 }
 
 .kpem-header-mobile .contenedor-logo img {
-  height: 56px;
+  height: 64px;
   width: auto;
   display: block;
 }
@@ -609,7 +609,7 @@ COMPONENTE: BOTÓN FLOTANTE DE LLAMADA A LA ACCIÓN (CTA) - DISEÑO PREMIUM
 }
 @media only screen and (max-width: 767px) {
   .kpem-header-mobile .contenedor-logo img {
-    height: 56px;
+    height: 64px;
     width: auto;
   }
   .menu-trigger {

--- a/estilos-header2.css
+++ b/estilos-header2.css
@@ -64,7 +64,7 @@ body {
 .kpem-header-mobile {
   width: 100%;
   height: 68px;
-  padding: 4px 16px;
+  padding: 0 16px;
   background: #fff;
   box-sizing: border-box;
   position: sticky;
@@ -83,10 +83,13 @@ body {
 
 .contenedor-logo {
   flex-grow: 0;
+  height: 100%;
+  display: flex;
+  align-items: center;
 }
 
 .kpem-header-mobile .contenedor-logo img {
-  height: 64px;
+  height: 66px;
   width: auto;
   display: block;
 }
@@ -609,7 +612,7 @@ COMPONENTE: BOTÓN FLOTANTE DE LLAMADA A LA ACCIÓN (CTA) - DISEÑO PREMIUM
 }
 @media only screen and (max-width: 767px) {
   .kpem-header-mobile .contenedor-logo img {
-    height: 64px;
+    height: 66px;
     width: auto;
   }
   .menu-trigger {

--- a/estilos-header2.css
+++ b/estilos-header2.css
@@ -63,7 +63,8 @@ body {
 }
 .kpem-header-mobile {
   width: 100%;
-  padding: 12px 20px;
+  height: 64px;
+  padding: 4px 16px;
   background: #fff;
   box-sizing: border-box;
   position: sticky;
@@ -85,8 +86,8 @@ body {
 }
 
 .kpem-header-mobile .contenedor-logo img {
-  width: 180px; /* tamaño original */
-  height: auto;
+  height: 56px;
+  width: auto;
   display: block;
 }
 
@@ -608,10 +609,11 @@ COMPONENTE: BOTÓN FLOTANTE DE LLAMADA A LA ACCIÓN (CTA) - DISEÑO PREMIUM
 }
 @media only screen and (max-width: 767px) {
   .kpem-header-mobile .contenedor-logo img {
-    width: 250px; /* tamaño original en móvil */
+    height: 56px;
+    width: auto;
   }
   .menu-trigger {
-    font-size: 50px; /* mantenemos botón compacto */
+    font-size: 50px;
   }
 }
 /* ===== Service breadcrumb (arriba, claro pero discreto) ===== */

--- a/estilos-header2.css
+++ b/estilos-header2.css
@@ -65,6 +65,7 @@ body {
   width: 100%;
   height: 68px;
   padding: 0 16px;
+  padding-top: 20px; /* Ajusta el valor "10px" a tu gusto */
   background: #fff;
   box-sizing: border-box;
   position: sticky;
@@ -86,6 +87,7 @@ body {
   height: 100%;
   display: flex;
   align-items: center;
+  line-height: 0; /* evita empuje por baseline (Safari) */
 }
 
 .kpem-header-mobile .contenedor-logo img {
@@ -94,17 +96,31 @@ body {
   display: block;
 }
 
-.menu-trigger {
-  font-size: 50px;
+.kpem-menu-trigger {
+  /* --- Propiedades Clave para Compatibilidad --- */
+  display: flex; /* 1. Define el botón como un contenedor flexible. */
+  align-items: center; /* 2. Centra el ícono verticalmente. */
+  justify-content: center; /* 3. Centra el ícono horizontalmente. */
+  line-height: 1; /* 4. Elimina la altura de línea conflictiva. */
+
+  /* --- Tu Estilo (con !important para asegurar que gane) --- */
+  font-size: 40px !important; /* Ajusta los 40px a tu gusto. */
+  padding: 12px;
+
+  /* --- Código Original --- */
   background: none;
   border: none;
   color: #212121;
   cursor: pointer;
   outline: none;
-  padding: 0 8px;
   flex-shrink: 0;
-}
 
+  /* --- Importante para Safari --- */
+  /* Desactiva la apariencia nativa del botón en iOS/Safari */
+  -webkit-appearance: none;
+  appearance: none;
+  border-radius: 0; /* Safari a veces añade un borde redondeado por defecto */
+}
 .menu-trigger:focus {
   outline: 2px solid #005fcc;
   outline-offset: 2px;
@@ -611,8 +627,12 @@ COMPONENTE: BOTÓN FLOTANTE DE LLAMADA A LA ACCIÓN (CTA) - DISEÑO PREMIUM
   stroke: #ffd700;
 }
 @media only screen and (max-width: 767px) {
+  .kpem-header-mobile {
+    height: 80px; /* header ligeramente mayor que el logo (200) */
+  }
   .kpem-header-mobile .contenedor-logo img {
-    height: 66px;
+    height: 250px; /* deja que el contenedor mande */
+    max-height: 100%; /* nunca más alto que el header */
     width: auto;
   }
   .menu-trigger {
@@ -764,19 +784,7 @@ COMPONENTE: BOTÓN FLOTANTE DE LLAMADA A LA ACCIÓN (CTA) - DISEÑO PREMIUM
 /* Accessible focus for service CTAs */
 .main-cta-button:focus-visible,
 .page .cta:focus-visible {
-  outline: 3px solid #ffd700;   /* gold brand */
+  outline: 3px solid #ffd700; /* gold brand */
   outline-offset: 2px;
   box-shadow: 0 0 0 2px #111827; /* dark halo for contrast */
-}
-/* === OVERRIDE: header 220px + logo 215px + centered (mobile-first) === */
-.kpem-header-mobile { height: 220px; padding: 0 16px; }
-.kpem-header-mobile .contenedor-logo { height: 100%; display: flex; align-items: center; }
-.kpem-header-mobile .contenedor-logo img {
-  height: 215px; width: auto; display: block;
-  padding-block: 2px; box-sizing: content-box;
-}
-@media only screen and (max-width: 767px) {
-  .kpem-header-mobile .contenedor-logo img {
-    height: 215px; padding-block: 2px; box-sizing: content-box;
-  }
 }

--- a/estilos-header2.css
+++ b/estilos-header2.css
@@ -85,7 +85,7 @@ body {
 }
 
 .kpem-header-mobile .contenedor-logo img {
-  width: 85px;
+  width: 180px; /* tamaño original */
   height: auto;
   display: block;
 }
@@ -608,10 +608,10 @@ COMPONENTE: BOTÓN FLOTANTE DE LLAMADA A LA ACCIÓN (CTA) - DISEÑO PREMIUM
 }
 @media only screen and (max-width: 767px) {
   .kpem-header-mobile .contenedor-logo img {
-    width: 85px;
+    width: 250px; /* tamaño original en móvil */
   }
   .menu-trigger {
-    font-size: 50px;
+    font-size: 50px; /* mantenemos botón compacto */
   }
 }
 /* ===== Service breadcrumb (arriba, claro pero discreto) ===== */

--- a/estilos-header2.css
+++ b/estilos-header2.css
@@ -768,3 +768,15 @@ COMPONENTE: BOTÓN FLOTANTE DE LLAMADA A LA ACCIÓN (CTA) - DISEÑO PREMIUM
   outline-offset: 2px;
   box-shadow: 0 0 0 2px #111827; /* dark halo for contrast */
 }
+/* === OVERRIDE: header 220px + logo 215px + centered (mobile-first) === */
+.kpem-header-mobile { height: 220px; padding: 0 16px; }
+.kpem-header-mobile .contenedor-logo { height: 100%; display: flex; align-items: center; }
+.kpem-header-mobile .contenedor-logo img {
+  height: 215px; width: auto; display: block;
+  padding-block: 2px; box-sizing: content-box;
+}
+@media only screen and (max-width: 767px) {
+  .kpem-header-mobile .contenedor-logo img {
+    height: 215px; padding-block: 2px; box-sizing: content-box;
+  }
+}

--- a/estilos-header2.css
+++ b/estilos-header2.css
@@ -85,7 +85,7 @@ body {
 }
 
 .kpem-header-mobile .contenedor-logo img {
-  width: 180px;
+  width: 85px;
   height: auto;
   display: block;
 }
@@ -607,14 +607,11 @@ COMPONENTE: BOTÓN FLOTANTE DE LLAMADA A LA ACCIÓN (CTA) - DISEÑO PREMIUM
   stroke: #ffd700;
 }
 @media only screen and (max-width: 767px) {
-  /* Logo más grande */
   .kpem-header-mobile .contenedor-logo img {
-    width: 250px;
+    width: 85px;
   }
-
-  /* Menú hamburguesa proporcional al logo */
   .menu-trigger {
-    font-size: 150px; /* antes 50px */
+    font-size: 50px;
   }
 }
 /* ===== Service breadcrumb (arriba, claro pero discreto) ===== */


### PR DESCRIPTION
Append override at end of estilos-header2.css to set header 220px and logo 215px; center via flex; add padding-block to avoid cropping; CSS-only, no HTML touched.