### PR TITLE
FIX: Hero CTA text overflow on iPhone mobile

### DIFF
--- a/estilos-header2.css
+++ b/estilos-header2.css
@@ -2119,7 +2119,16 @@ PHASE 2: PREMIUM CTA & CAROUSEL STYLES (RESTORED & FIXED)
   }
 
   .cta-text-single {
-    font-size: 1.15rem;
+    font-size: 1.1rem;
+    white-space: normal;
+    text-align: center;
+    line-height: 1.3;
+  }
+
+  .cta-content {
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5rem;
   }
 
   .hero-cta-button-premium .cta-icon-svg {


### PR DESCRIPTION
## Summary
- Fix phone number text overflowing outside yellow CTA button on iPhone/small mobile screens

## Changes
- Allow text wrapping (`white-space: normal`) on screens ≤600px
- Center text alignment for wrapped lines
- Adjust line-height for better readability
- Add flex-wrap to `.cta-content` container

## Test plan
- [ ] Test on iPhone Safari/Chrome (375px-414px width)
- [ ] Verify text stays inside yellow button
- [ ] Confirm desktop still shows single line

🤖 Generated with [Claude Code](https://claude.com/claude-code)