### PR TITLE
FIX: Hero CTA - Action text only on mobile (CRO)

### DIFF
--- a/estilos-header2.css
+++ b/estilos-header2.css
@@ -2101,8 +2101,9 @@ PHASE 2: PREMIUM CTA & CAROUSEL STYLES (RESTORED & FIXED)
   flex-shrink: 0;
 }
 
-/* Single Line Text - Large & Clear */
-.cta-text-single {
+/* CTA Text - Responsive Show/Hide */
+.cta-text-mobile,
+.cta-text-desktop {
   font-family: 'Inter', sans-serif;
   font-size: 1.5rem;
   font-weight: 700;
@@ -2111,29 +2112,46 @@ PHASE 2: PREMIUM CTA & CAROUSEL STYLES (RESTORED & FIXED)
   letter-spacing: 0.2px;
 }
 
+/* Mobile: Show short text, hide phone number */
+.cta-text-desktop {
+  display: none;
+}
+
+.cta-text-mobile {
+  display: inline;
+}
+
+/* Desktop: Show full text with phone number */
+@media (min-width: 601px) {
+  .cta-text-desktop {
+    display: inline;
+  }
+
+  .cta-text-mobile {
+    display: none;
+  }
+}
+
 /* Mobile: Responsive text size */
 @media (max-width: 600px) {
   .hero-cta-button-premium {
-    padding: 1.25rem 1.5rem;
-    width: 100%;
+    padding: 1rem 1.75rem;
+    width: auto;
+    max-width: 100%;
   }
 
-  .cta-text-single {
-    font-size: 1.1rem;
-    white-space: normal;
-    text-align: center;
-    line-height: 1.3;
+  .cta-text-mobile {
+    font-size: 1.15rem;
   }
 
   .cta-content {
-    flex-wrap: wrap;
     justify-content: center;
-    gap: 0.5rem;
+    gap: 0.6rem;
   }
 
   .hero-cta-button-premium .cta-icon-svg {
-    width: 26px;
-    height: 26px;
+    width: 24px;
+    height: 24px;
   }
 }
 
@@ -2248,9 +2266,9 @@ PHASE 2: PREMIUM CTA & CAROUSEL STYLES (RESTORED & FIXED)
   }
 
   .hero-cta-button-premium {
-    padding: 1.25rem 1.5rem;
+    padding: 1rem 1.75rem;
     max-width: 100%;
-    width: 100%;
+    width: auto;
     margin: 0 auto;
   }
 }

--- a/index.html
+++ b/index.html
@@ -163,7 +163,8 @@
                   d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z">
                 </path>
               </svg>
-              <span class="cta-text-single">Fix My Car Today — (250) 859-5467</span>
+              <span class="cta-text-mobile">Fix My Car Today</span>
+              <span class="cta-text-desktop">Fix My Car Today — (250) 859-5467</span>
             </span>
           </a>
           <!-- Secondary: Text Us -->


### PR DESCRIPTION
## Summary
- **Mobile:** "Fix My Car Today" (clean, one line)
- **Desktop:** "Fix My Car Today — (250) 859-5467" (full info)

## CRO Rationale
- Phone number is redundant on mobile (tap-to-call auto-dials)
- Action-oriented text converts better than informational text
- Less cognitive load = higher conversion rate

## Test plan
- [ ] Mobile: Verify single line "Fix My Car Today" displays
- [ ] Desktop: Verify full text with phone number displays
- [ ] Both: Confirm tap/click initiates call

🤖 Generated with [Claude Code](https://claude.com/claude-code)