### PR TITLE
feat(perf): preload hero images to reduce LCP

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,9 @@
   <meta name="theme-color" content="#E6B43C" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <!-- Preload hero image (LCP optimization) -->
+  <link rel="preload" as="image" href="images/hero-mechanic-400w.webp" media="(max-width: 640px)" type="image/webp">
+  <link rel="preload" as="image" href="images/hero-mechanic-800w.webp" media="(min-width: 641px) and (max-width: 1024px)" type="image/webp">
   <!-- Aquí conectas tu archivo CSS -->
   <link rel="stylesheet" href="estilos-header2.css" />
   <!-- ====================================================== -->

--- a/services/diagnostic/index.html
+++ b/services/diagnostic/index.html
@@ -33,6 +33,9 @@
   <meta property="og:url" content="https://kelownaprotechmobilemech.com/services/diagnostic/" />
   <meta property="og:image" content="https://kelownaprotechmobilemech.com/images/diagnostic-og.jpg" />
 
+  <!-- Preload hero image (LCP optimization) -->
+  <link rel="preload" as="image" href="/images/diagnostic-repairs-400w.webp" media="(max-width: 640px)" type="image/webp">
+  <link rel="preload" as="image" href="/images/diagnostic-repairs-800w.webp" media="(min-width: 641px) and (max-width: 1024px)" type="image/webp">
   <!-- CSS ya existente del sitio -->
   <link rel="stylesheet" href="/estilos-header2.css" />
   <link rel="stylesheet" href="/service-tiles.css" />

--- a/services/maintenance/index.html
+++ b/services/maintenance/index.html
@@ -136,6 +136,9 @@
       }
     </script>
 
+    <!-- Preload hero image (LCP optimization) -->
+    <link rel="preload" as="image" href="/images/maintenance-3v-400w.webp" media="(max-width: 640px)" type="image/webp">
+    <link rel="preload" as="image" href="/images/maintenance-3v-800w.webp" media="(min-width: 641px) and (max-width: 1024px)" type="image/webp">
     <link rel="stylesheet" href="/estilos-header2.css">
     <link rel="stylesheet" href="/service-tiles.css">
 

--- a/services/pre-purchase/index.html
+++ b/services/pre-purchase/index.html
@@ -186,6 +186,9 @@
       }
     </script>
   <!-- ====== Structured Data: Client Stories Page ====== -->
+  <!-- Preload hero image (LCP optimization) -->
+  <link rel="preload" as="image" href="/images/pre-purchase-400w.webp" media="(max-width: 640px)" type="image/webp">
+  <link rel="preload" as="image" href="/images/pre-purchase-800w.webp" media="(min-width: 641px) and (max-width: 1024px)" type="image/webp">
   <link rel="stylesheet" href="/estilos-header2.css" />
   <link rel="stylesheet" href="/service-tiles.css" />
 


### PR DESCRIPTION
## Summary
- Add `<link rel="preload">` for responsive hero images (400w, 800w) in all 4 pages
- Browser discovers LCP image immediately instead of waiting for HTML parser
- Expected LCP improvement: 3.9s → ~3.0-3.4s

## Changes
- `index.html` — preload hero-mechanic 400w/800w
- `services/diagnostic/index.html` — preload diagnostic-repairs 400w/800w
- `services/pre-purchase/index.html` — preload pre-purchase 400w/800w
- `services/maintenance/index.html` — preload maintenance-3v 400w/800w

## Why
PageSpeed Insights shows LCP at 3.9s (target: <2.5s). The hero image is the LCP element. Without preload, the browser only discovers the image URL after parsing ~150 lines of HTML + downloading render-blocking CSS.

## Test plan
- [x] All 4 pages have 2 preload tags each (verified with http.server)
- [x] Preloaded images resolve correctly (200 OK)
- [ ] Re-test PageSpeed Insights after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)