### PR TITLE
feat(perf): defer service-tiles.css to unblock FCP

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="service-tiles.css">
+  <link rel="stylesheet" href="service-tiles.css" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="service-tiles.css"></noscript>
   <!-- ====================================================== -->
   <!-- Structured Data for Home Page -->
   <!-- ====== Structured Data: Client Stories Page ====== -->

--- a/services/diagnostic/index.html
+++ b/services/diagnostic/index.html
@@ -38,7 +38,8 @@
   <link rel="preload" as="image" href="/images/diagnostic-repairs-800w.webp" media="(min-width: 641px) and (max-width: 1024px)" type="image/webp">
   <!-- CSS ya existente del sitio -->
   <link rel="stylesheet" href="/estilos-header2.css" />
-  <link rel="stylesheet" href="/service-tiles.css" />
+  <link rel="stylesheet" href="/service-tiles.css" media="print" onload="this.media='all'" />
+  <noscript><link rel="stylesheet" href="/service-tiles.css" /></noscript>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />

--- a/services/maintenance/index.html
+++ b/services/maintenance/index.html
@@ -140,7 +140,8 @@
     <link rel="preload" as="image" href="/images/maintenance-3v-400w.webp" media="(max-width: 640px)" type="image/webp">
     <link rel="preload" as="image" href="/images/maintenance-3v-800w.webp" media="(min-width: 641px) and (max-width: 1024px)" type="image/webp">
     <link rel="stylesheet" href="/estilos-header2.css">
-    <link rel="stylesheet" href="/service-tiles.css">
+    <link rel="stylesheet" href="/service-tiles.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="/service-tiles.css"></noscript>
 
     <!-- ENGINEERING AUTHORITY PREMIUM SYSTEM -->
     <style>

--- a/services/pre-purchase/index.html
+++ b/services/pre-purchase/index.html
@@ -190,7 +190,8 @@
   <link rel="preload" as="image" href="/images/pre-purchase-400w.webp" media="(max-width: 640px)" type="image/webp">
   <link rel="preload" as="image" href="/images/pre-purchase-800w.webp" media="(min-width: 641px) and (max-width: 1024px)" type="image/webp">
   <link rel="stylesheet" href="/estilos-header2.css" />
-  <link rel="stylesheet" href="/service-tiles.css" />
+  <link rel="stylesheet" href="/service-tiles.css" media="print" onload="this.media='all'" />
+  <noscript><link rel="stylesheet" href="/service-tiles.css" /></noscript>
 
   <!-- ENGINEERING AUTHORITY PREMIUM SYSTEM -->
   <style>


### PR DESCRIPTION
## Summary
- Load `service-tiles.css` asynchronously via `media="print"` + `onload` swap
- Tiles are below the fold — CSS not needed for initial paint
- `<noscript>` fallback for JS-disabled users

## Why
FCP is 3.2s (target: <1.8s). Three render-blocking CSS files in `<head>` prevent any paint until all download. `service-tiles.css` styles below-the-fold content only.

## Test plan
- [x] Pages load correctly with tiles styled after async load
- [x] `<noscript>` fallback present
- [ ] Re-test PageSpeed Insights after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)