### PR TITLE
feat(perf): async load Google Fonts to unblock FCP

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,8 @@
   <!-- ====================================================== -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="service-tiles.css" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="service-tiles.css"></noscript>
   <!-- ====================================================== -->

--- a/services/diagnostic/index.html
+++ b/services/diagnostic/index.html
@@ -42,7 +42,8 @@
   <noscript><link rel="stylesheet" href="/service-tiles.css" /></noscript>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'" />
+  <noscript><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" /></noscript>
   <!-- Estilos mínimos locales para esta página -->
   <style>
     :root {

--- a/services/pre-purchase/index.html
+++ b/services/pre-purchase/index.html
@@ -40,7 +40,8 @@
   <!-- Fuente (igual que en el resto del sitio) -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'" />
+  <noscript><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" /></noscript>
   <script type="application/ld+json">
       {
         "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- Make Google Fonts CSS non-render-blocking via `media="print"` + `onload` swap
- `display=swap` already in URL ensures text visible with fallback font during load
- Applied to: index.html, diagnostic, pre-purchase (maintenance doesn't load Fonts directly)

## Why
FCP 3.2s with 3 render-blocking CSS files. Google Fonts requires 2 network round-trips (CSS + font file). Making it async removes one render-blocking resource.

## Test plan
- [x] Text renders with system font first, swaps to Inter when loaded
- [x] `<noscript>` fallback present
- [ ] Re-test PageSpeed Insights after all 3 optimizations deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)