### PR TITLE
feat(perf): move GA4 script to end of body to free connections for LCP

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,15 +2,6 @@
 <html lang="en">
 
 <head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1GDM77733G"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() { dataLayer.push(arguments); }
-    gtag('js', new Date());
-
-    gtag('config', 'G-1GDM77733G');
-  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" type="image/png" sizes="32x32" href="/Favicon.png" />
@@ -836,6 +827,14 @@
     <span class="widget-text">Ask a Mechanic</span>
   </button>
 
+  <!-- Google tag (gtag.js) — moved to end of body to free connections for LCP -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1GDM77733G"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'G-1GDM77733G');
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- Moves GA4 `gtag.js` from `<head>` (line 5) to just before `</body>`
- On Lighthouse's slow 4G simulation (~1.6Mbps, 6 connections), GA consumes 2 connections before the hero image preload can start
- Moving it to the end prioritizes LCP-critical resources (hero image, CSS)

## Why
- **LCP is 3.9s** — the biggest remaining bottleneck (25% of score weight)
- GA works identically from any position in the document; only loses tracking of the first ~100ms of page load (negligible for analytics)
- Zero visual or functional impact

## Expected Impact
- LCP: 3.9s → ~3.2-3.4s (fewer connection conflicts)
- FCP: 2.6s → ~2.3-2.5s (parser hits content faster)
- TBT: may improve slightly (less JS competing during load)

## Test plan
- [ ] Run PageSpeed Insights mobile after deploy
- [ ] Verify GA4 still fires (check Real-Time in Google Analytics)
- [ ] Verify LCP improvement in Lighthouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)