### PR TITLE
fix: remove false claims and align credentials to real background

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,8 +160,8 @@
   "hasMap": "https://www.google.com/maps?cid=15158851769671529299",
   "aggregateRating": {
   "@type": "AggregateRating",
-  "ratingValue": "4.8",
-  "reviewCount": "20"
+  "ratingValue": "4.9",
+  "reviewCount": "36"
 },
   "telephone": "+1-250-859-5467",
   "address": {
@@ -299,7 +299,7 @@
           <div class="proof-rating-block">
             <div class="proof-rating-number">4.9</div>
             <div class="proof-rating-stars">★★★★★</div>
-            <div class="proof-rating-count">34 reviews</div>
+            <div class="proof-rating-count">36 reviews</div>
           </div>
 
           <!-- Center: Testimonial Carousel with Avatars -->
@@ -520,7 +520,7 @@
       ★ ★ ★ ★ ★ 
     </div>
     <div class="review-text"> 
-      <strong>4.9</strong> from 20+ reviews 
+      <strong>4.9</strong> from 36 reviews
     </div>
   </div> 
   -->

--- a/index.html
+++ b/index.html
@@ -6,16 +6,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" type="image/png" sizes="32x32" href="/Favicon.png" />
   <link rel="apple-touch-icon" sizes="180x180" href="/Favicon.png" />
-  <title>Mobile Mechanic Kelowna | Certified On-Site Repairs</title>
+  <title>Mobile Mechanic Kelowna | Certified Engineer On-Site Repairs</title>
   <meta name="description"
-    content="Car won’t start? Certified mobile diagnostics & repairs in your driveway (Kelowna). Clear test results, upfront pricing—no tow, no upsells. Call or text.">
+    content="Car won't start? Certified engineer — mobile diagnostics & repairs in your driveway (Kelowna). Clear test results, upfront pricing—no tow, no hidden fees. Call or text.">
   <meta name="robots" content="index, follow" />
   <link rel="canonical" href="https://kelownaprotechmobilemech.com/" />
   <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml" />
   <!-- Enhanced Open Graph Tags for Social Sharing -->
-  <meta property="og:title" content="Mobile Mechanic Kelowna | Certified On-Site Repairs" />
+  <meta property="og:title" content="Mobile Mechanic Kelowna | Certified Engineer On-Site Repairs" />
   <meta property="og:description"
-    content="Car won't start? Certified mobile diagnostics & repairs in your driveway (Kelowna). Clear test results, upfront pricing—no tow, no upsells. Call or text." />
+    content="Car won't start? Certified engineer — mobile diagnostics & repairs in your driveway (Kelowna). Clear test results, upfront pricing—no tow, no hidden fees. Call or text." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://kelownaprotechmobilemech.com/" />
   <meta property="og:image" content="https://kelownaprotechmobilemech.com/images/Gemini_Generated_Image_l9q0lql9q0lql9q0.webp" />
@@ -27,7 +27,7 @@
 
   <!-- Twitter Card Tags for Better Twitter Sharing -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Mobile Mechanic Kelowna | Certified On-Site Repairs" />
+  <meta name="twitter:title" content="Mobile Mechanic Kelowna | Certified Engineer On-Site Repairs" />
   <meta name="twitter:description" content="Car won't start? We come to you. Expert diagnostics in your driveway. 4.9★ rated | Same-day service | No tow needed" />
   <meta name="twitter:image" content="https://kelownaprotechmobilemech.com/images/Gemini_Generated_Image_l9q0lql9q0lql9q0.webp" />
   <meta name="twitter:image:alt" content="Mobile mechanic diagnosing car on-site in Kelowna" />
@@ -799,8 +799,8 @@
       <!-- Icono actualizado: Gem (especialista certificado) -->
       <img
         src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWdlbS1pY29uIGx1Y2lkZS1nZW0iPjxwYXRoIGQ9Ik0xMC41IDMgOCA5bDQgMTMgNC0xMy0yLjUtNiIvPjxwYXRoIGQ9Ik0xNyAzYTIgMiAwIDAgMSAxLjYuOGwzIDRhMiAyIDAgMCAxIC4wMTMgMi4zODJsLTcuOTkgMTAuOTg2YTIgMiAwIDAgMS0zLjI0NyAwbC03Ljk5LTEwLjk4NkEyIDIgMCAwIDEgMi40IDcuOGwyLjk5OC0zLjk5N0EyIDIgMCAwIDEgNyAzeiIvPjxwYXRoIGQ9Ik0yIDloMjAiLz48L3N2Zz4="
-        alt="Gem icon – Certified Specialist" class="icon-achievement" width="28" height="28" loading="lazy" />
-      <span>Certified<br>Specialist</span>
+        alt="Gem icon – Certified Mechanical Engineer" class="icon-achievement" width="28" height="28" loading="lazy" />
+      <span>Certified<br>Mech. Engineer</span>
     </div>
 
     <!-- Icono 2: Gauge – Precision Repairs -->

--- a/index.html
+++ b/index.html
@@ -772,11 +772,11 @@
 
       <!-- Paso 3: Valor (Result & WhatsApp) -->
       <div id="diag-step-3" class="diag-step" style="display:none;">
-        <div class="diag-success-icon">🤖</div>
-        <h2 class="diag-title">AI Analysis in Progress...</h2>
+        <div class="diag-success-icon">🔧</div>
+        <h2 class="diag-title">We're Reviewing Your Case</h2>
         <div class="diag-result-box">
           <p id="diag-result-placeholder">
-            Based on your description, our Master Mechanic Joseph is reviewing your case. We specialize in mobile
+            Based on your description, our lead engineer Joseph is reviewing your case. We specialize in mobile
             on-site
             repairs and can likely solve this today without a tow.
           </p>

--- a/services/diagnostic/index.html
+++ b/services/diagnostic/index.html
@@ -388,7 +388,7 @@
         <div class="badges">
           <span>✓ Engineering-Grade Tools</span>
           <span>✓ Same-Day Available</span>
-          <span>✓ 4.9★ (100+ Reviews)</span>
+          <span>✓ 4.9★ (36 Reviews)</span>
         </div>
       </div>
       <figure>

--- a/services/diagnostic/index.html
+++ b/services/diagnostic/index.html
@@ -583,11 +583,11 @@
 
       <!-- Paso 3: Valor (Result & WhatsApp) -->
       <div id="diag-step-3" class="diag-step" style="display:none;">
-        <div class="diag-success-icon">🤖</div>
-        <h2 class="diag-title">AI Analysis in Progress...</h2>
+        <div class="diag-success-icon">🔧</div>
+        <h2 class="diag-title">We're Reviewing Your Case</h2>
         <div class="diag-result-box">
           <p id="diag-result-placeholder">
-            Based on your description, our Master Mechanic Joseph is reviewing your case. We specialize in mobile
+            Based on your description, our lead engineer Joseph is reviewing your case. We specialize in mobile
             on-site repairs and can likely solve this today without a tow.
           </p>
         </div>

--- a/services/maintenance/index.html
+++ b/services/maintenance/index.html
@@ -557,11 +557,11 @@
 
       <!-- Paso 3: Valor (Result & WhatsApp) -->
       <div id="diag-step-3" class="diag-step" style="display:none;">
-        <div class="diag-success-icon">🤖</div>
-        <h2 class="diag-title">AI Analysis in Progress...</h2>
+        <div class="diag-success-icon">🔧</div>
+        <h2 class="diag-title">We're Reviewing Your Case</h2>
         <div class="diag-result-box">
           <p id="diag-result-placeholder">
-            Based on your description, our Master Mechanic Joseph is reviewing your case. We specialize in mobile
+            Based on your description, our lead engineer Joseph is reviewing your case. We specialize in mobile
             on-site repairs and can likely solve this today without a tow.
           </p>
         </div>

--- a/services/pre-purchase/index.html
+++ b/services/pre-purchase/index.html
@@ -589,11 +589,11 @@
 
       <!-- Paso 3: Valor (Result & WhatsApp) -->
       <div id="diag-step-3" class="diag-step" style="display:none;">
-        <div class="diag-success-icon">🤖</div>
-        <h2 class="diag-title">AI Analysis in Progress...</h2>
+        <div class="diag-success-icon">🔧</div>
+        <h2 class="diag-title">We're Reviewing Your Case</h2>
         <div class="diag-result-box">
           <p id="diag-result-placeholder">
-            Based on your description, our Master Mechanic Joseph is reviewing your case. We specialize in mobile
+            Based on your description, our lead engineer Joseph is reviewing your case. We specialize in mobile
             on-site repairs and can likely solve this today without a tow.
           </p>
         </div>

--- a/services/pre-purchase/index.html
+++ b/services/pre-purchase/index.html
@@ -374,10 +374,10 @@
 
             <!-- GRAND SLAM OFFER BOX -->
             <div class="offer-box-premium">
-              <span class="offer-badge">🛡️ $10,000 Buyer Protection Included</span>
+              <span class="offer-badge">🔍 75+ Point Engineering Inspection</span>
               <p class="offer-text-premium">
-                <strong>Engineering-grade inspection with dealer-level diagnostic tools.</strong>
-                Every inspection includes $10,000 mechanical breakdown insurance — at no extra cost. You're protected for 90 days or 4,000 km after purchase.
+                <strong>Professional damage report with estimated repair costs.</strong>
+                Use it to negotiate the price down, request repairs before closing, or compare better purchase options. Clear findings, real numbers — no guesswork.
               </p>
             </div>
 
@@ -385,9 +385,9 @@
             <div style="margin-top: 24px;">
               <a class="cta-premium-primary"
                 href="tel:+12508595467"
-                aria-label="Book $10k protected inspection with engineering-grade diagnostic — same day in Kelowna"
-                title="Call to book your protected pre-purchase inspection">
-                Get $10k Protected Inspection — Same Day ✓
+                aria-label="Book 75+ point pre-purchase inspection — same day in Kelowna"
+                title="Call to book your pre-purchase inspection">
+                Book Your 75+ Point Inspection — Same Day ✓
               </a>
               <a class="cta-premium-secondary"
                 href="sms:+12508595467"
@@ -465,15 +465,15 @@
             <p style="color: #94a3b8; font-size: 14px;">Oscar used our report to force the dealer to either fix it all or drop the price. They dropped the price.</p>
           </div>
           <div>
-            <h4 style="color: white; margin-bottom: 8px;">✓ $10k Insurance Included</h4>
-            <p style="color: #94a3b8; font-size: 14px;">Even after negotiating, Oscar got 90 days of mechanical breakdown coverage — standard with every KPEMM inspection.</p>
+            <h4 style="color: white; margin-bottom: 8px;">✓ Photo-Rich Report Included</h4>
+            <p style="color: #94a3b8; font-size: 14px;">Oscar used the detailed photo report with every finding documented to negotiate the price down at the dealer.</p>
           </div>
         </div>
 
         <!-- CTA Inside Case Study -->
         <div style="margin-top: 40px; text-align: center;">
           <a class="cta-premium-primary" href="tel:+12508595467" style="margin-right: 0;">
-            Get Your $10k Protected Inspection — Same Day ✓
+            Get Your 75+ Point Inspection — Same Day ✓
           </a>
         </div>
       </div>
@@ -483,12 +483,12 @@
     <section class="section">
       <h2>Don't Buy Blind. Get Engineering-Grade Protection.</h2>
       <p class="lead">
-        We bring dealer-level diagnostic tools to any location in Kelowna. Every inspection includes $10,000 mechanical breakdown insurance and a photo-rich report you can negotiate with. <strong>100+ vehicles inspected. 4.9★ rating. Same-day available.</strong>
+        We bring dealer-level diagnostic tools to any location in Kelowna. Every inspection includes a detailed photo-rich report you can negotiate with. <strong>100+ vehicles inspected. 4.9★ rating. Same-day available.</strong>
       </p>
       <div style="margin-top: 24px;">
         <a class="cta-premium-primary" href="tel:+12508595467"
-          aria-label="Call to book engineering-grade pre-purchase inspection with $10k protection">
-          Book $10k Protected Inspection — Call Now ✓
+          aria-label="Call to book pre-purchase inspection in Kelowna">
+          Book Your Inspection — Call Now ✓
         </a>
         <a class="cta-premium-secondary" href="sms:+12508595467"
           aria-label="Text for quick quote on inspection — 2 minute response">
@@ -543,8 +543,8 @@
   <div class="floating-cta-container" role="region" aria-label="Quick Contact">
     <a href="tel:+12508595467" id="main-cta-button" class="main-cta-button"
       style="background: linear-gradient(135deg, #0f172a 0%, #1e40af 100%) !important; color: #fff !important; border: 2px solid #fbbf24 !important; box-shadow: 0 8px 20px rgba(15, 23, 42, 0.4), 0 0 20px rgba(251, 191, 36, 0.3) !important;"
-      aria-label="Book Engineering-Grade Inspection with $10k Protection">
-      Book $10k Protected Inspection ✓
+      aria-label="Book pre-purchase inspection in Kelowna">
+      Book Pre-Purchase Inspection ✓
     </a>
   </div>
 
@@ -597,7 +597,7 @@
             on-site repairs and can likely solve this today without a tow.
           </p>
         </div>
-        <p class="diag-cta-text">To get your $10k protected inspection quote:</p>
+        <p class="diag-cta-text">To get your inspection quote:</p>
         <div class="diag-action-container">
           <a href="tel:+12508595467" class="diag-call-btn" style="background: #0f172a !important; border: 2px solid #fbbf24 !important;">Call for Same-Day Inspection ✓</a>
           <a href="sms:+12508595467" class="diag-sms-btn" style="background: transparent !important; border: 2px solid #0f172a !important; color: #0f172a !important;">Text for Quick Quote (2-Min)</a>


### PR DESCRIPTION
## Summary
- Remove fabricated $10,000 insurance claims from pre-purchase page (9 instances) — replaced with real value props (75+ point inspection, professional damage report with estimated repair costs)
- Replace fake "AI Analysis in Progress" with honest "We're Reviewing Your Case" across all 4 pages
- Replace "Master Mechanic" (unverified certification) with "lead engineer" (actual credential) across all 4 pages
- Unify review count from inconsistent 20/34/100+ to actual 36 reviews and 4.9 rating
- Replace "Certified Specialist" badge with "Certified Mech. Engineer" (real credential)
- Update title/OG/Twitter meta tags to "Certified Engineer On-Site Repairs"
- Replace "no upsells" with "no hidden fees" in meta descriptions

## Why
These claims represented legal/compliance risk under BC consumer protection law: fabricated insurance products, fake AI, inflated review numbers, and vague certifications. All replacements use real, verifiable differentiators backed by actual engineering background.

## Test plan
- [ ] Verify pre-purchase page renders correctly with new offer box text
- [ ] Verify modal step 3 shows "We're Reviewing Your Case" on all 4 pages
- [ ] Verify homepage title tag shows "Certified Engineer On-Site Repairs"
- [ ] Verify structured data rating matches visible content (4.9 / 36)
- [ ] Verify "Certified Mech. Engineer" badge on homepage trust bar
- [ ] Run Google Rich Results Test to validate structured data

🤖 Generated with [Claude Code](https://claude.com/claude-code)