### PR TITLE
fix(security): remove exposed HF_TOKEN and dead API call

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -1,5 +1,3 @@
-const HF_TOKEN = "PASTE_YOUR_TOKEN_HERE";
-
 /*
 ==========================================================================
 SECCIÓN: LÓGICA JAVASCRIPT
@@ -231,7 +229,7 @@ async function diagNext(step) {
       placeholder.innerHTML = "<em>Procesando diagnóstico experto...</em>";
     }
 
-    fetchAIAnalysis(currentLead);
+    displayExpertText(generateAIHypothesis(currentLead.symptoms));
 
     // LEAD COMPLETO: Toda la información capturada (listo para cotizar)
     const result = await sendLeadToAdmin({
@@ -378,55 +376,6 @@ function showLeadFeedback(success) {
       feedbackEl.style.display = 'none';
     }, 300);
   }, 3000);
-}
-
-/**
- * Fetches higher-authority analysis from Hugging Face Inference API.
- * Includes a 5-second timeout and CORS fallback.
- */
-async function fetchAIAnalysis(data) {
-  const placeholder = document.getElementById('diag-result-placeholder');
-  const API_URL = "https://api-inference.huggingface.co/models/mistralai/Mistral-7B-Instruct-v0.2";
-
-  // Timeout para evitar esperas infinitas
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 5000);
-
-  try {
-    const response = await fetch(API_URL, {
-      method: "POST",
-      headers: {
-        "Authorization": `Bearer ${HF_TOKEN}`,
-        "Content-Type": "application/json"
-      },
-      signal: controller.signal,
-      body: JSON.stringify({
-        inputs: `[SYS] You are a Master Mechanic in Kelowna. Analyze: ${data.symptoms} for a ${data.vehicle}. Respond in 3 short sentences using 'Chain Reaction' logic. [ANS]`,
-        parameters: { max_new_tokens: 150, temperature: 0.7 }
-      })
-    });
-
-    clearTimeout(timeoutId);
-
-    if (!response.ok) throw new Error("API Offline or CORS");
-
-    const result = await response.json();
-    let aiText = result[0]?.generated_text || result.generated_text || "";
-
-    if (aiText.includes("[ANS]")) {
-      aiText = aiText.split("[ANS]").pop().trim();
-    }
-
-    if (placeholder) {
-      displayExpertText(aiText || generateAIHypothesis(data.symptoms));
-    }
-  } catch (error) {
-    clearTimeout(timeoutId);
-    console.warn("🛡️ KPEM SAFE-MODE: El navegador bloqueó la IA (CORS). Activando Lógica Experta Local.");
-    if (placeholder) {
-      displayExpertText(generateAIHypothesis(data.symptoms));
-    }
-  }
 }
 
 /**


### PR DESCRIPTION
## What & Why

Removed a publicly-visible token placeholder and its associated dead API call from the client-side JavaScript.

**Problem:** `HF_TOKEN = "PASTE_YOUR_TOKEN_HERE"` was sitting on line 1 of the public JS file, visible to anyone opening browser DevTools. The function using it (`fetchAIAnalysis`) called the Hugging Face API from the browser — which means if a real token was ever pasted there, it would be fully exposed in network requests.

**Impact:** The API call always failed silently (CORS + placeholder token), so it fell through to the local `generateAIHypothesis()` function anyway. That local function was doing 100% of the real work.

## Changes

- `scripts.js`: Remove `HF_TOKEN` variable (line 1)
- `scripts.js`: Remove `fetchAIAnalysis()` function (48 lines deleted)
- `scripts.js`: Replace `fetchAIAnalysis(currentLead)` call with direct `displayExpertText(generateAIHypothesis(currentLead.symptoms))`

## User Impact

**Zero.** Diagnostic modal behavior is identical. Response is faster (no 5s timeout waiting for a dead API).

## Test Plan

- [ ] Open diagnostic modal → fill symptoms → click Analyze
- [ ] Verify expert analysis text appears correctly
- [ ] Open browser DevTools → confirm no HF_TOKEN in Sources
- [ ] Open Network tab → confirm no requests to huggingface.co

🤖 Generated with [Claude Code](https://claude.com/claude-code)