### PR TITLE
fix(seo): canonical, H1, meta title/description, sitemap lastmod

### DIFF
--- a/services/diagnostic/index.html
+++ b/services/diagnostic/index.html
@@ -19,7 +19,7 @@
     On-Site Car Diagnostic in Kelowna | Kelowna Protech Elite Mobile Mechanic
   </title>
   <meta name="description"
-    content="Check-engine light? Car won’t start? Get a same-day on-site diagnostic anywhere in Kelowna. Kelowna Protech Elite Mobile Mechanic finds the root cause fast—no towing, no guessing." />
+    content="Check-engine light? Car won’t start? Same-day on-site diagnostic in Kelowna. We find the root cause fast — no towing, no guessing." />
   <meta name="robots" content="index,follow" />
 
   <!-- Canonical de la URL final sin www -->
@@ -349,7 +349,7 @@
     <section class="hero" id="top">
       <div>
         <h1 class="services-heading">
-          Kelowna Protech Elite Mobile Mechanic
+          On-Site Car Diagnostic Kelowna — Same-Day Service
         </h1>
         <h2 class="services-subheading">
           Mobile Mechanic Kelowna — Same-Day On-Site Diagnostics & Clear

--- a/services/maintenance/index.html
+++ b/services/maintenance/index.html
@@ -18,7 +18,7 @@
     <title>Preventive Maintenance in Kelowna | Mobile Mechanic | Kelowna Protech Elite Mobile Mechanic</title>
     <meta name="description" content="Preventive maintenance at your location. Dealer‑level checks and a simple, photo‑rich report. 100+ services completed in Kelowna.">
     <meta name="robots" content="index,follow">
-
+    <link rel="canonical" href="https://kelownaprotechmobilemech.com/services/maintenance/" />
 
     <meta property="og:title" content="Preventive Maintenance in Kelowna | Mobile Mechanic">
     <meta property="og:description" content="Preventive maintenance at your location. Dealer‑level checks and a simple, photo‑rich report.">

--- a/services/pre-purchase/index.html
+++ b/services/pre-purchase/index.html
@@ -16,10 +16,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/Favicon.png" />
   <link rel="apple-touch-icon" sizes="180x180" href="/Favicon.png" />
 
-  <title>
-    Pre‑Purchase Inspection in Kelowna | Mobile Mechanic | Kelowna Protech
-    Elite Mobile Mechanic
-  </title>
+  <title>Pre-Purchase Inspection Kelowna | Kelowna Protech Elite</title>
   <meta name="description"
     content="Avoid scams and costly surprises. We inspect the car like it was ours—dealer‑level scan, photo‑rich report, and clear next steps. 100+ inspections completed in Kelowna." />
   <meta name="robots" content="index,follow" />

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,18 +2,18 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://kelownaprotechmobilemech.com/</loc>
-    <lastmod>2025-10-17</lastmod>
+    <lastmod>2026-02-28</lastmod>
   </url>
   <url>
     <loc>https://kelownaprotechmobilemech.com/services/diagnostic/</loc>
-    <lastmod>2025-10-17</lastmod>
+    <lastmod>2026-02-28</lastmod>
   </url>
   <url>
     <loc>https://kelownaprotechmobilemech.com/services/pre-purchase/</loc>
-    <lastmod>2025-10-17</lastmod>
+    <lastmod>2026-02-28</lastmod>
   </url>
   <url>
     <loc>https://kelownaprotechmobilemech.com/services/maintenance/</loc>
-    <lastmod>2025-10-17</lastmod>
+    <lastmod>2026-02-28</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary

- **Maintenance page:** Added missing `<link rel="canonical">` tag
- **Diagnostic page:** H1 changed from brand name → keyword-rich `On-Site Car Diagnostic Kelowna — Same-Day Service`
- **Pre-Purchase page:** Meta title shortened from 93 chars → 55 chars
- **Diagnostic page:** Meta description trimmed from 184 chars → 130 chars (under 155 limit)
- **sitemap.xml:** All 4 `<lastmod>` dates updated to `2026-02-28`

## Files modified

| File | Change |
|------|--------|
| `services/maintenance/index.html` | Added canonical tag |
| `services/diagnostic/index.html` | H1 + meta description |
| `services/pre-purchase/index.html` | Meta title |
| `sitemap.xml` | lastmod × 4 |

## Test plan

- [ ] Validate canonical tags with Google Rich Results or browser inspector
- [ ] Confirm H1 renders correctly on diagnostic page (mobile + desktop)
- [ ] Confirm meta title ≤ 60 chars on pre-purchase page
- [ ] Confirm meta description ≤ 155 chars on diagnostic page
- [ ] Validate sitemap.xml at `/sitemap.xml` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)