### PR TITLE
docs: clarify GA4 Key Events operational structure

### DIFF
--- a/DOCS/PROJECT_MASTER.md
+++ b/DOCS/PROJECT_MASTER.md
@@ -47,6 +47,23 @@ We position as the **Blue Ocean Alternative** to both:
 - **Event Tracking:** Lead generation, CTA clicks, form abandonment
 - **Lead Value:** $150 CAD per complete lead
 
+### 📊 Estructura Operativa de Medición (GA4)
+
+**🚨 ATENCIÓN PARA REPORTES Y CRO:** Para medir el rendimiento comercial del sitio, se debe observar exclusivamente la tasa de conversión de los contactos reales.
+
+**1. Conversiones Comerciales (KPIs Principales)**
+*Marcados activamente como Key Events en GA4.*
+- `phone_click`
+- `sms_click`
+
+**2. Microconversiones (Análisis de Comportamiento)**
+*Medidos como eventos estándar, desactivados como Key Events.*
+- `service_card_click`
+
+**3. Ruido del Sistema (Ignorar en lecturas)**
+- `purchase`: Aparece listado por limitación inherente de la plataforma GA4. Tiene 0 datos y debe ignorarse operativamente.
+- `click`: Obsoleto y removido de Key Events.
+
 ### Email & Forms
 - **FormSubmit.co** (Free tier, unlimited)
 - **Endpoint:** info@kelownaprotechmobilemech.com


### PR DESCRIPTION
## Cambios Realizados
- Actualización de `DOCS/PROJECT_MASTER.md` para aclarar la estructura de medición de GA4.
- Documentado `phone_click` y `sms_click` como Key Events principales (Conversiones reales).
- Documentado `service_card_click` como Microconversión (evento estándar).
- Documentado `purchase` y `click` como eventos a ignorar operativamente.

## Alcance
- [x] Solo incluye cambios de documentación de GA4
- [x] No incluye cambios de diseño, código o copy