### PR TITLE
feat(cro): mobile CTA bar — immediate call-to-action above the fold

### DIFF
--- a/estilos-header2.css
+++ b/estilos-header2.css
@@ -1542,6 +1542,51 @@ COMPONENTE: BOTÓN FLOTANTE DE LLAMADA A LA ACCIÓN (CTA) - DISEÑO PREMIUM
 
 
 /* ================================================================
+   Mobile CTA Bar: immediate call-to-action below header
+   - Visible only on mobile (≤1023px), hidden on desktop
+   - Static position: scrolls with content; floating CTA covers scroll
+   ================================================================ */
+.mobile-cta-bar {
+  display: none;
+}
+
+@media (max-width: 1023px) {
+  .mobile-cta-bar {
+    display: block;
+    background: #0f172a;
+    padding: 10px 16px;
+    text-align: center;
+  }
+
+  .mobile-cta-bar a {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: #ffffff;
+    font-family: "Inter", 'Inter Fallback', sans-serif;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    text-decoration: none;
+    letter-spacing: 0.2px;
+  }
+
+  .mobile-cta-bar a:active {
+    opacity: 0.85;
+  }
+
+  .mobile-cta-bar svg {
+    flex-shrink: 0;
+  }
+
+  .mobile-cta-bar-sub {
+    color: #94a3b8;
+    font-weight: 400;
+    font-size: 0.8125rem;
+  }
+}
+
+
+/* ================================================================
    PHASE 1: CRO URGENT FIXES - Hero CTA & Social Proof
    ================================================================ */
 

--- a/index.html
+++ b/index.html
@@ -102,6 +102,10 @@
       -moz-osx-font-smoothing: grayscale
     }
 
+    .mobile-cta-bar {
+      display: none
+    }
+
     .hero-image {
       aspect-ratio: 800/437;
       width: 100%;
@@ -252,6 +256,34 @@
         visibility: hidden !important;
         opacity: 0 !important;
         pointer-events: none !important
+      }
+
+      .mobile-cta-bar {
+        display: block;
+        background: #0f172a;
+        padding: 10px 16px;
+        text-align: center
+      }
+
+      .mobile-cta-bar a {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        color: #fff;
+        font-family: "Inter", 'Inter Fallback', sans-serif;
+        font-size: .9375rem;
+        font-weight: 600;
+        text-decoration: none
+      }
+
+      .mobile-cta-bar svg {
+        flex-shrink: 0
+      }
+
+      .mobile-cta-bar-sub {
+        color: #94a3b8;
+        font-weight: 400;
+        font-size: .8125rem
       }
 
       .floating-cta-container {
@@ -1116,6 +1148,18 @@
     </button>
   </header>
 
+  <!-- Mobile CTA Bar: immediate call-to-action below header (mobile only) -->
+  <div class="mobile-cta-bar">
+    <a href="tel:+12508595467" aria-label="Call expert mechanic for same-day service">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+        stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
+        width="18" height="18" aria-hidden="true">
+        <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/>
+      </svg>
+      <span>Call Expert Mechanic</span>
+      <span class="mobile-cta-bar-sub">Same-Day Service</span>
+    </a>
+  </div>
 
   <!-- Componente 3: Sección Hero ("Our Promise") -->
   <section id="our-promise" class="hero-section">


### PR DESCRIPTION
## Summary
- Adds a full-width **"Call Expert Mechanic · Same-Day Service"** bar directly below the header on mobile (≤1023px)
- Gives users an immediate `tel:` action above the fold without any scroll
- Static position: scrolls with content; the existing floating CTA covers scroll depth
- Hidden on desktop (`display: none`) — zero visual impact on desktop layout

## CRO Context
Resolves the #1 finding from `DOCS/HOMEPAGE-CRO-AUDIT-2026-03-11.md`:
> "La homepage móvil no ofrece una acción principal inmediata y dominante antes del scroll."

## Files Changed
| File | Change |
|------|--------|
| `index.html` | New `.mobile-cta-bar` HTML element after `</header>` + critical inline CSS |
| `estilos-header2.css` | New `.mobile-cta-bar` styles (mobile-only media query) |

## What was NOT touched
- Header layout (logo, hamburger, nav) — untouched
- Desktop styles — untouched
- Hero grid/order — untouched (separate future change)
- Floating CTA — untouched
- Tracking/GA4 — untouched
- Service pages — untouched

## Test plan
- [x] Mobile (375px): CTA bar visible below header, tappable `tel:` link
- [x] Tablet (768px): CTA bar visible, layout correct
- [x] Desktop (1280px): CTA bar hidden, header CTA visible with subtitle
- [x] Zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)