### PR TITLE
fix: GA4 tracking cleanup + mobile CTA visibility

### DIFF
--- a/estilos-header2.css
+++ b/estilos-header2.css
@@ -2968,6 +2968,31 @@ LEAD FEEDBACK TOAST - Confirmación visual de envío
     object-position: center top;
   }
 
+  .hero-intro {
+    margin-bottom: 0.25rem;
+  }
+
+  .hero-headline {
+    font-size: 1.75rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .hero-support-text {
+    font-size: 1rem;
+    line-height: 1.5;
+    margin-bottom: 0.75rem;
+  }
+
+  .hero-value-list {
+    margin-top: 0.5rem !important;
+    font-size: 0.875rem !important;
+    line-height: 1.4 !important;
+  }
+
+  .hero-value-list li {
+    margin-bottom: 0.2rem !important;
+  }
+
   .hero-cta-container {
     margin-top: 0.75rem;
   }

--- a/estilos-header2.css
+++ b/estilos-header2.css
@@ -2940,3 +2940,35 @@ LEAD FEEDBACK TOAST - Confirmación visual de envío
     text-align: center;
   }
 }
+
+/* FIX 4: Hide floating CTA widget on mobile — blocks contact CTAs at 390px */
+@media (max-width: 768px) {
+  .floating-cta-container {
+    display: none !important;
+  }
+}
+
+/* FIX 5: Compress hero section on mobile so headline + subheadline + CTA
+   are all visible within the first 100vh at 390x844px.
+   Desktop (min-width: 769px) is untouched. */
+@media (max-width: 768px) {
+  .hero-section {
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem;
+  }
+
+  .hero-grid {
+    gap: 0.5rem;
+  }
+
+  .hero-visual-column .hero-image {
+    max-height: 180px;
+    width: 100%;
+    object-fit: cover;
+    object-position: center top;
+  }
+
+  .hero-cta-container {
+    margin-top: 0.75rem;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1159,8 +1159,7 @@
         <!-- Main CTA Buttons Row -->
         <div class="hero-cta-buttons">
           <!-- Primary: Call Now -->
-          <a href="tel:+12508595467" class="hero-cta-button-premium hero-cta-call"
-            onclick="if(typeof gtag === 'function') { gtag('event', 'click_to_call', { 'event_category': 'Lead Generation', 'event_label': 'Hero CTA - Primary', 'button_location': 'hero_primary' }); }">
+          <a href="tel:+12508595467" class="hero-cta-button-premium hero-cta-call">
             <span class="cta-content">
               <svg class="cta-icon-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
                 stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">

--- a/scripts.js
+++ b/scripts.js
@@ -206,7 +206,7 @@ async function diagNext(step) {
 
     // GA4 Tracking - Partial Lead Captured
     if (typeof gtag === 'function') {
-      gtag('event', 'generate_lead', {
+      gtag('event', 'lead_step_1', {
         'event_category': 'Lead Generation',
         'event_label': 'Partial Lead - Step 1 Complete',
         'funnel_step': 'step_1_complete',
@@ -512,13 +512,17 @@ document.addEventListener('DOMContentLoaded', function () {
 
       // Send event to GA4
       if (typeof gtag === 'function') {
-        gtag('event', 'phone_click', {
+        const phoneEventParams = {
           'event_category': 'conversion',
           'event_label': linkText || 'Phone Click',
           'phone_number': phoneNumber,
           'link_class': linkClass,
           'page_location': window.location.pathname
-        });
+        };
+        if (this.id === 'main-cta-button' || this.closest('.floating-cta-container')) {
+          phoneEventParams['button_location'] = 'floating_widget';
+        }
+        gtag('event', 'phone_click', phoneEventParams);
       }
 
     });


### PR DESCRIPTION
## Summary
- Remove duplicate inline `onclick` from hero CTA (Fix 1) — one click was firing two GA4 events
- Rename partial lead event `generate_lead` → `lead_step_1` (Fix 2) — GA4 was double-counting every lead
- Add `button_location: floating_widget` to `phone_click` event for floating widget clicks (Fix 3) — all phone clicks looked identical in GA4
- Hide `.floating-cta-container` on mobile ≤768px (Fix 4) — widget was blocking contact CTAs on 390px screens
- Compress hero section on mobile so headline + subheadline + CTA button are all visible within first 100vh at 390x844px (Fix 5)

## Test plan
- [x] Verified CTA button visible in first 100vh at 390x844px (mobile screenshot confirmed)
- [x] Desktop layout untouched (existing rule already hides floating widget at ≥1024px)
- [x] `generate_lead` for complete lead (line ~249 in scripts.js) untouched
- [x] Zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)