### PR TITLE
fix(a11y+security): modal aria-labels, broken nav, focus, skip-link, CSP

### DIFF
--- a/_headers
+++ b/_headers
@@ -5,6 +5,7 @@
   Permissions-Policy: interest-cohort=()
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   X-Robots-Tag: noarchive
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: blob:; connect-src 'self' https://formsubmit.co https://www.google-analytics.com https://region1.google-analytics.com; frame-ancestors 'none';
 
 /sitemap.xml
   Content-Type: application/xml

--- a/_headers
+++ b/_headers
@@ -5,7 +5,7 @@
   Permissions-Policy: interest-cohort=()
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   X-Robots-Tag: noarchive
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: blob:; connect-src 'self' https://formsubmit.co https://www.google-analytics.com https://region1.google-analytics.com; frame-ancestors 'none';
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: blob:; connect-src 'self' https://formsubmit.co https://www.google-analytics.com https://region1.google-analytics.com https://analytics.google.com https://stats.g.doubleclick.net; frame-ancestors 'none';
 
 /sitemap.xml
   Content-Type: application/xml

--- a/estilos-header2.css
+++ b/estilos-header2.css
@@ -1,3 +1,20 @@
+/* Skip-to-content link (accessibility) */
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 0;
+  z-index: 10000;
+  padding: 8px 16px;
+  background: #005fcc;
+  color: #fff;
+  font-weight: 700;
+  text-decoration: none;
+  border-radius: 0 0 4px 0;
+}
+.skip-link:focus {
+  top: 0;
+}
+
 /*
  * ==================================================================
  * RESET DE CSS MODERNO Y NORMALIZACIÓN
@@ -123,7 +140,6 @@ body {
   border: none;
   color: #212121;
   cursor: pointer;
-  outline: none;
   flex-shrink: 0;
 
   /* --- Importante para Safari --- */
@@ -134,7 +150,7 @@ body {
   /* Safari a veces añade un borde redondeado por defecto */
 }
 
-.menu-trigger:focus {
+.kpem-menu-trigger:focus-visible {
   outline: 2px solid #005fcc;
   outline-offset: 2px;
 }

--- a/field-reports/bmw-z3-kelowna-diagnostic/index.html
+++ b/field-reports/bmw-z3-kelowna-diagnostic/index.html
@@ -523,6 +523,7 @@
 </head>
 
 <body>
+  <a href="#top" class="skip-link">Skip to main content</a>
   <!-- HEADER MOBILE -->
   <header class="kpem-header-mobile" role="banner">
     <div class="contenedor-logo">
@@ -762,10 +763,10 @@
         <h2 class="diag-title">Step 1: Contact Details</h2>
         <p class="diag-subtitle">Where should we send your results?</p>
         <div class="diag-input-group">
-          <input type="text" id="diag-name" placeholder="Your Name" required>
+          <input type="text" id="diag-name" aria-label="Your name" placeholder="Your Name" required>
         </div>
         <div class="diag-input-group">
-          <input type="text" id="diag-contact" placeholder="Phone or Email" required>
+          <input type="text" id="diag-contact" aria-label="Phone or email" placeholder="Phone or Email" required>
         </div>
         <button class="diag-next-btn" onclick="diagNext(2)">Next: Vehicle Info →</button>
         <p class="diag-privacy">We only use this to send your diagnostic report.</p>
@@ -775,14 +776,14 @@
       <div id="diag-step-2" class="diag-step" style="display:none;">
         <h2 class="diag-title">Step 2: Vehicle &amp; Symptoms</h2>
         <div class="diag-input-group">
-          <input type="text" id="diag-vehicle" placeholder="Year / Make / Model (e.g., 2018 Ford F-150)">
+          <input type="text" id="diag-vehicle" aria-label="Vehicle year, make and model" placeholder="Year / Make / Model (e.g., 2018 Ford F-150)">
         </div>
         <div class="diag-input-group">
-          <textarea id="diag-symptoms"
+          <textarea id="diag-symptoms" aria-label="Describe what is happening with your vehicle"
             placeholder="Tell us what's happening (e.g., ticking noise, won't start, warning light...)"></textarea>
         </div>
         <div class="diag-input-group">
-          <select id="diag-urgency">
+          <select id="diag-urgency" aria-label="How urgent is your situation">
             <option value="flexible">Urgency: Flexible</option>
             <option value="24h">Need help within 24h</option>
             <option value="emergency">Emergency / Broken Down</option>

--- a/field-reports/index.html
+++ b/field-reports/index.html
@@ -286,6 +286,7 @@
 </head>
 
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
   <!-- HEADER MOBILE -->
   <header class="kpem-header-mobile" role="banner">
     <div class="contenedor-logo">
@@ -313,7 +314,7 @@
     </button>
   </header>
 
-  <main class="page">
+  <main class="page" id="main-content">
     <!-- Breadcrumb -->
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <a href="/">Home</a> › Success Stories
@@ -407,10 +408,10 @@
         <h2 class="diag-title">Step 1: Contact Details</h2>
         <p class="diag-subtitle">Where should we send your results?</p>
         <div class="diag-input-group">
-          <input type="text" id="diag-name" placeholder="Your Name" required>
+          <input type="text" id="diag-name" aria-label="Your name" placeholder="Your Name" required>
         </div>
         <div class="diag-input-group">
-          <input type="text" id="diag-contact" placeholder="Phone or Email" required>
+          <input type="text" id="diag-contact" aria-label="Phone or email" placeholder="Phone or Email" required>
         </div>
         <button class="diag-next-btn" onclick="diagNext(2)">Next: Vehicle Info →</button>
         <p class="diag-privacy">We only use this to send your diagnostic report.</p>
@@ -420,14 +421,14 @@
       <div id="diag-step-2" class="diag-step" style="display:none;">
         <h2 class="diag-title">Step 2: Vehicle & Symptoms</h2>
         <div class="diag-input-group">
-          <input type="text" id="diag-vehicle" placeholder="Year / Make / Model (e.g., 2018 Ford F-150)">
+          <input type="text" id="diag-vehicle" aria-label="Vehicle year, make and model" placeholder="Year / Make / Model (e.g., 2018 Ford F-150)">
         </div>
         <div class="diag-input-group">
-          <textarea id="diag-symptoms"
+          <textarea id="diag-symptoms" aria-label="Describe what is happening with your vehicle"
             placeholder="Tell us what's happening (e.g., ticking noise, won't start, warning light...)"></textarea>
         </div>
         <div class="diag-input-group">
-          <select id="diag-urgency">
+          <select id="diag-urgency" aria-label="How urgent is your situation">
             <option value="flexible">Urgency: Flexible</option>
             <option value="24h">Need help within 24h</option>
             <option value="emergency">Emergency / Broken Down</option>

--- a/index.html
+++ b/index.html
@@ -728,6 +728,7 @@
 </head>
 
 <body>
+  <a href="#hero" class="skip-link">Skip to main content</a>
   <!-- INICIO HEADER MOBILE -->
   <!-- Mobile Header -->
   <header class="kpem-header-mobile" role="banner">
@@ -742,10 +743,9 @@
       <button class="menu-close-button" aria-label="Close menu">&times;</button>
       <ul>
         <li><a href="#client-stories">Client Stories</a></li>
-        <li><a href="#why-us">Why Us</a></li>
+        <li><a href="#commercial-faq">Why Us</a></li>
         <li><a href="#service-tiles">Services</a></li>
         <li><a href="/field-reports/">Success Stories</a></li>
-        <li><a href="#contact">Contact</a></li>
       </ul>
     </nav>
     <a href="tel:+12508595467" class="header-cta" aria-label="Call expert mechanic for same-day service">
@@ -1138,10 +1138,10 @@
         <h2 class="diag-title">Step 1: Contact Details</h2>
         <p class="diag-subtitle">Where should we send your results?</p>
         <div class="diag-input-group">
-          <input type="text" id="diag-name" placeholder="Your Name" required>
+          <input type="text" id="diag-name" aria-label="Your name" placeholder="Your Name" required>
         </div>
         <div class="diag-input-group">
-          <input type="text" id="diag-contact" placeholder="Phone or Email" required>
+          <input type="text" id="diag-contact" aria-label="Phone or email" placeholder="Phone or Email" required>
         </div>
         <button class="diag-next-btn" onclick="diagNext(2)">Next: Vehicle Info →</button>
         <p class="diag-privacy">We only use this to send your diagnostic report.</p>
@@ -1151,14 +1151,14 @@
       <div id="diag-step-2" class="diag-step" style="display:none;">
         <h2 class="diag-title">Step 2: Vehicle & Symptoms</h2>
         <div class="diag-input-group">
-          <input type="text" id="diag-vehicle" placeholder="Year / Make / Model (e.g., 2018 Ford F-150)">
+          <input type="text" id="diag-vehicle" aria-label="Vehicle year, make and model" placeholder="Year / Make / Model (e.g., 2018 Ford F-150)">
         </div>
         <div class="diag-input-group">
-          <textarea id="diag-symptoms"
+          <textarea id="diag-symptoms" aria-label="Describe what is happening with your vehicle"
             placeholder="Tell us what's happening (e.g., ticking noise, won't start, warning light...)"></textarea>
         </div>
         <div class="diag-input-group">
-          <select id="diag-urgency">
+          <select id="diag-urgency" aria-label="How urgent is your situation">
             <option value="flexible">Urgency: Flexible</option>
             <option value="24h">Need help within 24h</option>
             <option value="emergency">Emergency / Broken Down</option>

--- a/services/diagnostic/index.html
+++ b/services/diagnostic/index.html
@@ -320,6 +320,7 @@
 </head>
 
 <body>
+  <a href="#top" class="skip-link">Skip to main content</a>
   <!-- HEADER MOBILE -->
   <header class="kpem-header-mobile" role="banner">
     <div class="contenedor-logo">
@@ -558,10 +559,10 @@
         <h2 class="diag-title">Step 1: Contact Details</h2>
         <p class="diag-subtitle">Where should we send your results?</p>
         <div class="diag-input-group">
-          <input type="text" id="diag-name" placeholder="Your Name" required>
+          <input type="text" id="diag-name" aria-label="Your name" placeholder="Your Name" required>
         </div>
         <div class="diag-input-group">
-          <input type="text" id="diag-contact" placeholder="Phone or Email" required>
+          <input type="text" id="diag-contact" aria-label="Phone or email" placeholder="Phone or Email" required>
         </div>
         <button class="diag-next-btn" onclick="diagNext(2)">Next: Vehicle Info →</button>
         <p class="diag-privacy">We only use this to send your diagnostic report.</p>
@@ -571,14 +572,14 @@
       <div id="diag-step-2" class="diag-step" style="display:none;">
         <h2 class="diag-title">Step 2: Vehicle & Symptoms</h2>
         <div class="diag-input-group">
-          <input type="text" id="diag-vehicle" placeholder="Year / Make / Model (e.g., 2018 Ford F-150)">
+          <input type="text" id="diag-vehicle" aria-label="Vehicle year, make and model" placeholder="Year / Make / Model (e.g., 2018 Ford F-150)">
         </div>
         <div class="diag-input-group">
-          <textarea id="diag-symptoms"
+          <textarea id="diag-symptoms" aria-label="Describe what is happening with your vehicle"
             placeholder="Tell us what's happening (e.g., ticking noise, won't start, warning light...)"></textarea>
         </div>
         <div class="diag-input-group">
-          <select id="diag-urgency">
+          <select id="diag-urgency" aria-label="How urgent is your situation">
             <option value="flexible">Urgency: Flexible</option>
             <option value="24h">Need help within 24h</option>
             <option value="emergency">Emergency / Broken Down</option>

--- a/services/maintenance/index.html
+++ b/services/maintenance/index.html
@@ -328,6 +328,7 @@
     </style>
   </head>
   <body>
+  <a href="#main" class="skip-link">Skip to main content</a>
   <!-- HEADER MOBILE -->
   <header class="kpem-header-mobile" role="banner">
     <div class="contenedor-logo">
@@ -548,10 +549,10 @@
         <h2 class="diag-title">Step 1: Contact Details</h2>
         <p class="diag-subtitle">Where should we send your results?</p>
         <div class="diag-input-group">
-          <input type="text" id="diag-name" placeholder="Your Name" required>
+          <input type="text" id="diag-name" aria-label="Your name" placeholder="Your Name" required>
         </div>
         <div class="diag-input-group">
-          <input type="text" id="diag-contact" placeholder="Phone or Email" required>
+          <input type="text" id="diag-contact" aria-label="Phone or email" placeholder="Phone or Email" required>
         </div>
         <button class="diag-next-btn" onclick="diagNext(2)">Next: Vehicle Info →</button>
         <p class="diag-privacy">We only use this to send your diagnostic report.</p>
@@ -561,14 +562,14 @@
       <div id="diag-step-2" class="diag-step" style="display:none;">
         <h2 class="diag-title">Step 2: Vehicle & Symptoms</h2>
         <div class="diag-input-group">
-          <input type="text" id="diag-vehicle" placeholder="Year / Make / Model (e.g., 2018 Ford F-150)">
+          <input type="text" id="diag-vehicle" aria-label="Vehicle year, make and model" placeholder="Year / Make / Model (e.g., 2018 Ford F-150)">
         </div>
         <div class="diag-input-group">
-          <textarea id="diag-symptoms"
+          <textarea id="diag-symptoms" aria-label="Describe what is happening with your vehicle"
             placeholder="Tell us what's happening (e.g., ticking noise, won't start, warning light...)"></textarea>
         </div>
         <div class="diag-input-group">
-          <select id="diag-urgency">
+          <select id="diag-urgency" aria-label="How urgent is your situation">
             <option value="flexible">Urgency: Flexible</option>
             <option value="24h">Need help within 24h</option>
             <option value="emergency">Emergency / Broken Down</option>

--- a/services/pre-purchase/index.html
+++ b/services/pre-purchase/index.html
@@ -328,6 +328,7 @@
 </head>
 
 <body>
+  <a href="#main" class="skip-link">Skip to main content</a>
   <!-- HEADER MOBILE -->
   <header class="kpem-header-mobile" role="banner">
     <div class="contenedor-logo">
@@ -564,10 +565,10 @@
         <h2 class="diag-title">Step 1: Contact Details</h2>
         <p class="diag-subtitle">Where should we send your results?</p>
         <div class="diag-input-group">
-          <input type="text" id="diag-name" placeholder="Your Name" required>
+          <input type="text" id="diag-name" aria-label="Your name" placeholder="Your Name" required>
         </div>
         <div class="diag-input-group">
-          <input type="text" id="diag-contact" placeholder="Phone or Email" required>
+          <input type="text" id="diag-contact" aria-label="Phone or email" placeholder="Phone or Email" required>
         </div>
         <button class="diag-next-btn" onclick="diagNext(2)">Next: Vehicle Info →</button>
         <p class="diag-privacy">We only use this to send your diagnostic report.</p>
@@ -577,14 +578,14 @@
       <div id="diag-step-2" class="diag-step" style="display:none;">
         <h2 class="diag-title">Step 2: Vehicle & Symptoms</h2>
         <div class="diag-input-group">
-          <input type="text" id="diag-vehicle" placeholder="Year / Make / Model (e.g., 2018 Ford F-150)">
+          <input type="text" id="diag-vehicle" aria-label="Vehicle year, make and model" placeholder="Year / Make / Model (e.g., 2018 Ford F-150)">
         </div>
         <div class="diag-input-group">
-          <textarea id="diag-symptoms"
+          <textarea id="diag-symptoms" aria-label="Describe what is happening with your vehicle"
             placeholder="Tell us what's happening (e.g., ticking noise, won't start, warning light...)"></textarea>
         </div>
         <div class="diag-input-group">
-          <select id="diag-urgency">
+          <select id="diag-urgency" aria-label="How urgent is your situation">
             <option value="flexible">Urgency: Flexible</option>
             <option value="24h">Need help within 24h</option>
             <option value="emergency">Emergency / Broken Down</option>


### PR DESCRIPTION
## Summary

- **P1 — Accessibility (CRITICAL):** Add `aria-label` to all 5 modal inputs (`diag-name`, `diag-contact`, `diag-vehicle`, `diag-symptoms`, `diag-urgency`) across 6 HTML pages — resolves WCAG 2.1 AA violation
- **P2 — Broken nav links:** Fix `#why-us` → `#commercial-faq` (section exists in DOM); remove orphaned `#contact` link (no target section exists)
- **P3 — Keyboard focus:** Fix `.kpem-menu-trigger:focus-visible` selector mismatch; remove `outline: none` from base rule
- **P4 — Skip link (WCAG 2.4.1):** Add `.skip-link` to all 6 pages and shared CSS — hidden off-screen, visible on keyboard focus
- **P5 — CSP:** Add `Content-Security-Policy` header to `_headers` restricting to known origins (`googletagmanager`, `google-analytics`, `fonts.googleapis.com`, `formsubmit.co`)

## ⚠️ CSP Verification Required

`_headers` is only applied by Netlify CDN — not by local dev server. Before merging:
1. Check Netlify deploy preview console for any `Content Security Policy` errors
2. Verify GA4 tracking fires correctly (check Network tab for requests to `google-analytics.com`)
3. If CSP violations appear, update `connect-src` with missing domains before merge

## Test plan

- [ ] Open modal on homepage → inspect inputs in DevTools Accessibility panel → confirm labels announced
- [ ] Tap "Why Us" in mobile nav → scrolls to FAQ section
- [ ] Confirm "Contact" no longer appears in mobile nav
- [ ] Tab to hamburger button → blue outline visible
- [ ] Tab once on page load → skip link appears at top of page
- [ ] Check Netlify deploy preview console for CSP violations
- [ ] Verify GA4 events fire in Real-Time dashboard after deploy preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)