### PR TITLE
fix: remove inline onclick handlers — migrate to addEventListener in scripts.js

### DIFF
--- a/field-reports/bmw-z3-kelowna-diagnostic/index.html
+++ b/field-reports/bmw-z3-kelowna-diagnostic/index.html
@@ -754,7 +754,7 @@
   <!-- MODAL DEL EMBUDO DE DIAGNÓSTICO AI -->
   <div id="diag-modal" class="diag-modal-overlay" aria-hidden="true">
     <div class="diag-modal-content">
-      <button class="diag-close" onclick="closeDiagModal()" aria-label="Close diagnostic tool">&times;</button>
+      <button class="diag-close" aria-label="Close diagnostic tool">&times;</button>
 
       <!-- Paso 1 -->
       <div id="diag-step-1" class="diag-step">
@@ -766,7 +766,7 @@
         <div class="diag-input-group">
           <input type="text" id="diag-contact" aria-label="Phone or email" placeholder="Phone or Email" required>
         </div>
-        <button class="diag-next-btn" onclick="diagNext(2)">Next: Vehicle Info →</button>
+        <button class="diag-next-btn" data-step="2">Next: Vehicle Info →</button>
         <p class="diag-privacy">We only use this to send your diagnostic report.</p>
       </div>
 
@@ -787,7 +787,7 @@
             <option value="emergency">Emergency / Broken Down</option>
           </select>
         </div>
-        <button class="diag-next-btn" onclick="diagNext(3)">Analyze Now — Get Results →</button>
+        <button class="diag-next-btn" data-step="3">Analyze Now — Get Results →</button>
       </div>
 
       <!-- Paso 3 -->
@@ -814,7 +814,7 @@
   </div>
 
   <!-- RED SIDE WIDGET (ASK A MECHANIC) -->
-  <button id="side-ask-mechanic" class="side-ask-mechanic-btn" onclick="openDiagModal()"
+  <button id="side-ask-mechanic" class="side-ask-mechanic-btn"
     aria-label="Ask a Mechanic - Free Diagnostic">
     <span class="widget-text">Ask a Mechanic</span>
   </button>

--- a/field-reports/index.html
+++ b/field-reports/index.html
@@ -399,7 +399,7 @@
   <!-- MODAL DEL EMBUDO DE DIAGNÓSTICO AI -->
   <div id="diag-modal" class="diag-modal-overlay" aria-hidden="true">
     <div class="diag-modal-content">
-      <button class="diag-close" onclick="closeDiagModal()" aria-label="Close diagnostic tool">&times;</button>
+      <button class="diag-close" aria-label="Close diagnostic tool">&times;</button>
 
       <!-- Paso 1 -->
       <div id="diag-step-1" class="diag-step">
@@ -411,7 +411,7 @@
         <div class="diag-input-group">
           <input type="text" id="diag-contact" aria-label="Phone or email" placeholder="Phone or Email" required>
         </div>
-        <button class="diag-next-btn" onclick="diagNext(2)">Next: Vehicle Info →</button>
+        <button class="diag-next-btn" data-step="2">Next: Vehicle Info →</button>
         <p class="diag-privacy">We only use this to send your diagnostic report.</p>
       </div>
 
@@ -432,7 +432,7 @@
             <option value="emergency">Emergency / Broken Down</option>
           </select>
         </div>
-        <button class="diag-next-btn" onclick="diagNext(3)">Analyze Now — Get Results →</button>
+        <button class="diag-next-btn" data-step="3">Analyze Now — Get Results →</button>
       </div>
 
       <!-- Paso 3 -->
@@ -459,7 +459,7 @@
   </div>
 
   <!-- RED SIDE WIDGET -->
-  <button id="side-ask-mechanic" class="side-ask-mechanic-btn" onclick="openDiagModal()"
+  <button id="side-ask-mechanic" class="side-ask-mechanic-btn"
     aria-label="Ask a Mechanic - Free Diagnostic">
     <span class="widget-text">Ask a Mechanic</span>
   </button>

--- a/index.html
+++ b/index.html
@@ -1131,7 +1131,7 @@
   <!-- MODAL DEL EMBUDO DE DIAGNÓSTICO AI -->
   <div id="diag-modal" class="diag-modal-overlay" aria-hidden="true">
     <div class="diag-modal-content">
-      <button class="diag-close" onclick="closeDiagModal()" aria-label="Close diagnostic tool">&times;</button>
+      <button class="diag-close" aria-label="Close diagnostic tool">&times;</button>
 
       <!-- Paso 1: Lead (Hook + Contact) -->
       <div id="diag-step-1" class="diag-step">
@@ -1143,7 +1143,7 @@
         <div class="diag-input-group">
           <input type="text" id="diag-contact" aria-label="Phone or email" placeholder="Phone or Email" required>
         </div>
-        <button class="diag-next-btn" onclick="diagNext(2)">Next: Vehicle Info →</button>
+        <button class="diag-next-btn" data-step="2">Next: Vehicle Info →</button>
         <p class="diag-privacy">We only use this to send your diagnostic report.</p>
       </div>
 
@@ -1164,7 +1164,7 @@
             <option value="emergency">Emergency / Broken Down</option>
           </select>
         </div>
-        <button class="diag-next-btn" onclick="diagNext(3)">Analyze Now — Get Results →</button>
+        <button class="diag-next-btn" data-step="3">Analyze Now — Get Results →</button>
       </div>
 
       <!-- Paso 3: Valor (Result & WhatsApp) -->
@@ -1219,7 +1219,7 @@
   </div>
 
   <!-- RED SIDE WIDGET (ASK A MECHANIC) -->
-  <button id="side-ask-mechanic" class="side-ask-mechanic-btn" onclick="openDiagModal()"
+  <button id="side-ask-mechanic" class="side-ask-mechanic-btn"
     aria-label="Ask a Mechanic - Free Diagnostic">
     <span class="widget-text">Ask a Mechanic</span>
   </button>

--- a/scripts.js
+++ b/scripts.js
@@ -605,3 +605,34 @@ document.addEventListener('DOMContentLoaded', function () {
   // checkScroll(); // Check on load
   checkScroll(); // Check on load
 });
+
+
+/*
+==========================================================================
+DIAGNOSTIC MODAL — Event listeners (replaces inline onclick attributes)
+==========================================================================
+Binds openDiagModal, closeDiagModal, and diagNext() via addEventListener
+so that no inline onclick attributes are needed in the HTML.
+diagNext() reads data-step="2|3" from the button to determine the step.
+*/
+
+document.addEventListener('DOMContentLoaded', function () {
+  // Open modal — side widget button
+  document.querySelectorAll('#side-ask-mechanic-btn').forEach(function (btn) {
+    btn.addEventListener('click', openDiagModal);
+  });
+
+  // Close modal — close button inside modal
+  document.querySelectorAll('.diag-close').forEach(function (btn) {
+    btn.addEventListener('click', closeDiagModal);
+  });
+
+  // Advance modal steps — reads data-step attribute
+  document.querySelectorAll('.diag-next-btn').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      const step = parseInt(this.dataset.step, 10);
+      if (!step) return;
+      diagNext(step);
+    });
+  });
+});

--- a/scripts.js
+++ b/scripts.js
@@ -617,8 +617,8 @@ diagNext() reads data-step="2|3" from the button to determine the step.
 */
 
 document.addEventListener('DOMContentLoaded', function () {
-  // Open modal — side widget button
-  document.querySelectorAll('#side-ask-mechanic-btn').forEach(function (btn) {
+  // Open modal — side widget button (class selector; ID is "side-ask-mechanic")
+  document.querySelectorAll('.side-ask-mechanic-btn').forEach(function (btn) {
     btn.addEventListener('click', openDiagModal);
   });
 

--- a/services/diagnostic/index.html
+++ b/services/diagnostic/index.html
@@ -577,7 +577,7 @@
   <!-- MODAL DEL EMBUDO DE DIAGNÓSTICO AI -->
   <div id="diag-modal" class="diag-modal-overlay" aria-hidden="true">
     <div class="diag-modal-content">
-      <button class="diag-close" onclick="closeDiagModal()" aria-label="Close diagnostic tool">&times;</button>
+      <button class="diag-close" aria-label="Close diagnostic tool">&times;</button>
 
       <!-- Paso 1: Lead (Hook + Contact) -->
       <div id="diag-step-1" class="diag-step">
@@ -589,7 +589,7 @@
         <div class="diag-input-group">
           <input type="text" id="diag-contact" aria-label="Phone or email" placeholder="Phone or Email" required>
         </div>
-        <button class="diag-next-btn" onclick="diagNext(2)">Next: Vehicle Info →</button>
+        <button class="diag-next-btn" data-step="2">Next: Vehicle Info →</button>
         <p class="diag-privacy">We only use this to send your diagnostic report.</p>
       </div>
 
@@ -610,7 +610,7 @@
             <option value="emergency">Emergency / Broken Down</option>
           </select>
         </div>
-        <button class="diag-next-btn" onclick="diagNext(3)">Analyze Now — Get Results →</button>
+        <button class="diag-next-btn" data-step="3">Analyze Now — Get Results →</button>
       </div>
 
       <!-- Paso 3: Valor (Result & WhatsApp) -->
@@ -633,7 +633,7 @@
   </div>
 
   <!-- RED SIDE WIDGET (ASK A MECHANIC) -->
-  <button id="side-ask-mechanic" class="side-ask-mechanic-btn" onclick="openDiagModal()"
+  <button id="side-ask-mechanic" class="side-ask-mechanic-btn"
     aria-label="Ask a Mechanic - Free Diagnostic">
     <span class="widget-text">Ask a Mechanic</span>
   </button>

--- a/services/maintenance/index.html
+++ b/services/maintenance/index.html
@@ -536,7 +536,7 @@
   <!-- MODAL DEL EMBUDO DE DIAGNÓSTICO AI -->
   <div id="diag-modal" class="diag-modal-overlay" aria-hidden="true">
     <div class="diag-modal-content">
-      <button class="diag-close" onclick="closeDiagModal()" aria-label="Close diagnostic tool">&times;</button>
+      <button class="diag-close" aria-label="Close diagnostic tool">&times;</button>
 
       <!-- Paso 1: Lead (Hook + Contact) -->
       <div id="diag-step-1" class="diag-step">
@@ -548,7 +548,7 @@
         <div class="diag-input-group">
           <input type="text" id="diag-contact" aria-label="Phone or email" placeholder="Phone or Email" required>
         </div>
-        <button class="diag-next-btn" onclick="diagNext(2)">Next: Vehicle Info →</button>
+        <button class="diag-next-btn" data-step="2">Next: Vehicle Info →</button>
         <p class="diag-privacy">We only use this to send your diagnostic report.</p>
       </div>
 
@@ -569,7 +569,7 @@
             <option value="emergency">Emergency / Broken Down</option>
           </select>
         </div>
-        <button class="diag-next-btn" onclick="diagNext(3)">Analyze Now — Get Results →</button>
+        <button class="diag-next-btn" data-step="3">Analyze Now — Get Results →</button>
       </div>
 
       <!-- Paso 3: Valor (Result & WhatsApp) -->
@@ -592,7 +592,7 @@
   </div>
 
   <!-- RED SIDE WIDGET (ASK A MECHANIC) -->
-  <button id="side-ask-mechanic" class="side-ask-mechanic-btn" onclick="openDiagModal()"
+  <button id="side-ask-mechanic" class="side-ask-mechanic-btn"
     aria-label="Ask a Mechanic - Free Diagnostic">
     <span class="widget-text">Ask a Mechanic</span>
   </button>

--- a/services/pre-purchase/index.html
+++ b/services/pre-purchase/index.html
@@ -530,7 +530,7 @@
   <!-- MODAL DEL EMBUDO DE DIAGNÓSTICO AI -->
   <div id="diag-modal" class="diag-modal-overlay" aria-hidden="true">
     <div class="diag-modal-content">
-      <button class="diag-close" onclick="closeDiagModal()" aria-label="Close diagnostic tool">&times;</button>
+      <button class="diag-close" aria-label="Close diagnostic tool">&times;</button>
 
       <!-- Paso 1: Lead (Hook + Contact) -->
       <div id="diag-step-1" class="diag-step">
@@ -542,7 +542,7 @@
         <div class="diag-input-group">
           <input type="text" id="diag-contact" aria-label="Phone or email" placeholder="Phone or Email" required>
         </div>
-        <button class="diag-next-btn" onclick="diagNext(2)">Next: Vehicle Info →</button>
+        <button class="diag-next-btn" data-step="2">Next: Vehicle Info →</button>
         <p class="diag-privacy">We only use this to send your diagnostic report.</p>
       </div>
 
@@ -563,7 +563,7 @@
             <option value="emergency">Emergency / Broken Down</option>
           </select>
         </div>
-        <button class="diag-next-btn" onclick="diagNext(3)">Analyze Now — Get Results →</button>
+        <button class="diag-next-btn" data-step="3">Analyze Now — Get Results →</button>
       </div>
 
       <!-- Paso 3: Valor (Result & WhatsApp) -->
@@ -586,7 +586,7 @@
   </div>
 
   <!-- RED SIDE WIDGET (ASK A MECHANIC) -->
-  <button id="side-ask-mechanic" class="side-ask-mechanic-btn" onclick="openDiagModal()"
+  <button id="side-ask-mechanic" class="side-ask-mechanic-btn"
     aria-label="Ask a Mechanic - Free Diagnostic">
     <span class="widget-text">Ask a Mechanic</span>
   </button>


### PR DESCRIPTION
## Summary
- Added a `DOMContentLoaded` event listener block in `scripts.js` for `.side-ask-mechanic-btn`, `.diag-close`, and `.diag-next-btn` (reads `data-step` attribute)
- Removed all 24 inline `onclick` attributes from 6 HTML files
- Added `data-step="2|3"` to `.diag-next-btn` buttons to pass step context without inline JS

## Test plan
- [x] `grep onclick **/*.html` → 0 matches
- [x] Side widget → modal opens
- [x] Step 1 → Step 2 navigation
- [x] Step 2 → Step 3 with AI hypothesis
- [x] Close button → modal dismisses
- [x] Zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)