### PR TITLE
fix(a11y): add role=dialog, aria-modal, aria-labelledby to diag modal

### DIFF
--- a/field-reports/bmw-z3-kelowna-diagnostic/index.html
+++ b/field-reports/bmw-z3-kelowna-diagnostic/index.html
@@ -752,13 +752,13 @@
   </div>
 
   <!-- MODAL DEL EMBUDO DE DIAGNÓSTICO AI -->
-  <div id="diag-modal" class="diag-modal-overlay" aria-hidden="true">
+  <div id="diag-modal" class="diag-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="diag-modal-title" aria-hidden="true">
     <div class="diag-modal-content">
       <button class="diag-close" aria-label="Close diagnostic tool">&times;</button>
 
       <!-- Paso 1 -->
       <div id="diag-step-1" class="diag-step">
-        <h2 class="diag-title">Step 1: Contact Details</h2>
+        <h2 id="diag-modal-title" class="diag-title">Step 1: Contact Details</h2>
         <p class="diag-subtitle">Where should we send your results?</p>
         <div class="diag-input-group">
           <input type="text" id="diag-name" aria-label="Your name" placeholder="Your Name" required>

--- a/field-reports/index.html
+++ b/field-reports/index.html
@@ -397,13 +397,13 @@
   </div>
 
   <!-- MODAL DEL EMBUDO DE DIAGNÓSTICO AI -->
-  <div id="diag-modal" class="diag-modal-overlay" aria-hidden="true">
+  <div id="diag-modal" class="diag-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="diag-modal-title" aria-hidden="true">
     <div class="diag-modal-content">
       <button class="diag-close" aria-label="Close diagnostic tool">&times;</button>
 
       <!-- Paso 1 -->
       <div id="diag-step-1" class="diag-step">
-        <h2 class="diag-title">Step 1: Contact Details</h2>
+        <h2 id="diag-modal-title" class="diag-title">Step 1: Contact Details</h2>
         <p class="diag-subtitle">Where should we send your results?</p>
         <div class="diag-input-group">
           <input type="text" id="diag-name" aria-label="Your name" placeholder="Your Name" required>

--- a/index.html
+++ b/index.html
@@ -1129,13 +1129,13 @@
   <!-- FIN BOTÓN FLOTANTE CTA -->
 
   <!-- MODAL DEL EMBUDO DE DIAGNÓSTICO AI -->
-  <div id="diag-modal" class="diag-modal-overlay" aria-hidden="true">
+  <div id="diag-modal" class="diag-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="diag-modal-title" aria-hidden="true">
     <div class="diag-modal-content">
       <button class="diag-close" aria-label="Close diagnostic tool">&times;</button>
 
       <!-- Paso 1: Lead (Hook + Contact) -->
       <div id="diag-step-1" class="diag-step">
-        <h2 class="diag-title">Step 1: Contact Details</h2>
+        <h2 id="diag-modal-title" class="diag-title">Step 1: Contact Details</h2>
         <p class="diag-subtitle">Where should we send your results?</p>
         <div class="diag-input-group">
           <input type="text" id="diag-name" aria-label="Your name" placeholder="Your Name" required>

--- a/services/diagnostic/index.html
+++ b/services/diagnostic/index.html
@@ -575,13 +575,13 @@
   </div>
 
   <!-- MODAL DEL EMBUDO DE DIAGNÓSTICO AI -->
-  <div id="diag-modal" class="diag-modal-overlay" aria-hidden="true">
+  <div id="diag-modal" class="diag-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="diag-modal-title" aria-hidden="true">
     <div class="diag-modal-content">
       <button class="diag-close" aria-label="Close diagnostic tool">&times;</button>
 
       <!-- Paso 1: Lead (Hook + Contact) -->
       <div id="diag-step-1" class="diag-step">
-        <h2 class="diag-title">Step 1: Contact Details</h2>
+        <h2 id="diag-modal-title" class="diag-title">Step 1: Contact Details</h2>
         <p class="diag-subtitle">Where should we send your results?</p>
         <div class="diag-input-group">
           <input type="text" id="diag-name" aria-label="Your name" placeholder="Your Name" required>

--- a/services/maintenance/index.html
+++ b/services/maintenance/index.html
@@ -534,13 +534,13 @@
   </div>
 
   <!-- MODAL DEL EMBUDO DE DIAGNÓSTICO AI -->
-  <div id="diag-modal" class="diag-modal-overlay" aria-hidden="true">
+  <div id="diag-modal" class="diag-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="diag-modal-title" aria-hidden="true">
     <div class="diag-modal-content">
       <button class="diag-close" aria-label="Close diagnostic tool">&times;</button>
 
       <!-- Paso 1: Lead (Hook + Contact) -->
       <div id="diag-step-1" class="diag-step">
-        <h2 class="diag-title">Step 1: Contact Details</h2>
+        <h2 id="diag-modal-title" class="diag-title">Step 1: Contact Details</h2>
         <p class="diag-subtitle">Where should we send your results?</p>
         <div class="diag-input-group">
           <input type="text" id="diag-name" aria-label="Your name" placeholder="Your Name" required>

--- a/services/pre-purchase/index.html
+++ b/services/pre-purchase/index.html
@@ -528,13 +528,13 @@
   </div>
 
   <!-- MODAL DEL EMBUDO DE DIAGNÓSTICO AI -->
-  <div id="diag-modal" class="diag-modal-overlay" aria-hidden="true">
+  <div id="diag-modal" class="diag-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="diag-modal-title" aria-hidden="true">
     <div class="diag-modal-content">
       <button class="diag-close" aria-label="Close diagnostic tool">&times;</button>
 
       <!-- Paso 1: Lead (Hook + Contact) -->
       <div id="diag-step-1" class="diag-step">
-        <h2 class="diag-title">Step 1: Contact Details</h2>
+        <h2 id="diag-modal-title" class="diag-title">Step 1: Contact Details</h2>
         <p class="diag-subtitle">Where should we send your results?</p>
         <div class="diag-input-group">
           <input type="text" id="diag-name" aria-label="Your name" placeholder="Your Name" required>


### PR DESCRIPTION
## Summary
- Adds `role="dialog"`, `aria-modal="true"`, and `aria-labelledby="diag-modal-title"` to the `#diag-modal` container across all 6 pages
- Adds `id="diag-modal-title"` to the Step 1 heading so screen readers announce the modal name on open
- All 5 form fields already had `aria-label` — no changes needed there

## Why
Without `role="dialog"`, screen readers don't announce the modal as a dialog when it opens, even if `aria-hidden` is toggled correctly. This is a WCAG 2.1 dialog pattern requirement.

## Test plan
- [ ] `netlify dev --port 8888` — trigger modal on any page, confirm it opens/closes normally
- [ ] macOS VoiceOver (`Cmd+F5`): should announce "Step 1: Contact Details, dialog" on open
- [ ] Tab through fields — VoiceOver reads each `aria-label`
- [ ] Escape closes modal, focus returns to trigger button

🤖 Generated with [Claude Code](https://claude.com/claude-code)