### PR TITLE
fix(seo): correct data inconsistencies — hours, review count, priceRange, sitemap

### DIFF
--- a/field-reports/bmw-z3-kelowna-diagnostic/index.html
+++ b/field-reports/bmw-z3-kelowna-diagnostic/index.html
@@ -707,7 +707,7 @@
         </a>
       </div>
       <div class="badges">
-        <span>✓ 4.9★ (41 Reviews)</span>
+        <span>✓ 4.9★ (45 Reviews)</span>
         <span>✓ 15+ Years Engineering Experience</span>
         <span>✓ 100+ On-Site Diagnostics</span>
       </div>
@@ -733,7 +733,7 @@
           <a href="tel:+12508595467" class="site-nap__tel" rel="nofollow">+1‑250‑859‑5467</a>
         </div>
         <div class="site-nap__hours">
-          Hours: <time>Mon–Sun 08:00–20:00</time>
+          Hours: <time>Mon–Sat 08:00–18:00</time>
         </div>
         <p class="site-nap__coverage">
           <a href="/#coverage" class="site-nap__link">See Coverage &amp; Areas Served →</a>

--- a/field-reports/index.html
+++ b/field-reports/index.html
@@ -359,7 +359,7 @@
           aria-label="Text Joseph at (250) 859-5467">Text for Quote</a>
       </div>
       <div style="display:flex; gap:20px; align-items:center; justify-content:center; margin-top:28px; color:#94a3b8; font-size:13px; flex-wrap:wrap;">
-        <span>✓ 4.9★ (41 Reviews)</span>
+        <span>✓ 4.9★ (45 Reviews)</span>
         <span>✓ 15+ Years Engineering Experience</span>
         <span>✓ 100+ On-Site Diagnostics</span>
       </div>
@@ -378,7 +378,7 @@
           <a href="tel:+12508595467" class="site-nap__tel" rel="nofollow">+1‑250‑859‑5467</a>
         </div>
         <div class="site-nap__hours">
-          Hours: <time>Mon–Sun 08:00–20:00</time>
+          Hours: <time>Mon–Sat 08:00–18:00</time>
         </div>
         <p class="site-nap__coverage">
           <a href="/#coverage" class="site-nap__link">See Coverage & Areas Served →</a>

--- a/index.html
+++ b/index.html
@@ -697,7 +697,7 @@
     { "@type": "Neighborhood", "name": "East Kelowna" },
     { "@type": "Neighborhood", "name": "South Kelowna" }
   ],
-  "priceRange": "$$$",
+  "priceRange": "$$",
   "openingHoursSpecification": [
     {
       "@type": "OpeningHoursSpecification",
@@ -775,9 +775,9 @@
   <!-- FOLD 03: Hero Section -->
   <section id="hero" class="hero-fold">
     <div class="hero-fold__content">
-      <div class="hero-fold__trust" aria-label="Trusted by 42 Google reviewers">
-        <p class="hero-fold__trust-stars" aria-label="Rated 4.9 out of 5 from 42 Google reviews">
-          ★★★★★<span class="hero-fold__trust-meta">4.9 · Trusted by 42 Google Reviews</span>
+      <div class="hero-fold__trust" aria-label="Trusted by 45 Google reviewers">
+        <p class="hero-fold__trust-stars" aria-label="Rated 4.9 out of 5 from 45 Google reviews">
+          ★★★★★<span class="hero-fold__trust-meta">4.9 · Trusted by 45 Google Reviews</span>
         </p>
         <p class="hero-fold__trust-quote">"Honest mechanic who shows you what's actually wrong." &mdash; Tyler T.</p>
       </div>

--- a/services/diagnostic/index.html
+++ b/services/diagnostic/index.html
@@ -421,7 +421,7 @@
         <div class="badges">
           <span>✓ Engineering-Grade Tools</span>
           <span>✓ Same-Day Available</span>
-          <span>✓ 4.9★ (41 Reviews)</span>
+          <span>✓ 4.9★ (45 Reviews)</span>
         </div>
       </div>
       <figure>
@@ -556,7 +556,7 @@
           <a href="tel:+12508595467" class="site-nap__tel" rel="nofollow">+1‑250‑859‑5467</a>
         </div>
         <div class="site-nap__hours">
-          Hours: <time>Mon–Sun 08:00–20:00</time>
+          Hours: <time>Mon–Sat 08:00–18:00</time>
         </div>
         <p class="site-nap__coverage">
           <a href="/#coverage" class="site-nap__link">See Coverage & Areas Served →</a>

--- a/services/maintenance/index.html
+++ b/services/maintenance/index.html
@@ -516,7 +516,7 @@
           <div class="site-nap__contact">
             Phone: <a href="tel:+12508595467" class="site-nap__tel" rel="nofollow">+1‑250‑859‑5467</a>
           </div>
-          <div class="site-nap__hours">Hours: <time>Mon–Sun 08:00–20:00</time></div>
+          <div class="site-nap__hours">Hours: <time>Mon–Sat 08:00–18:00</time></div>
           <p class="site-nap__coverage">
             <a href="/#coverage" class="site-nap__link">See Coverage & Areas Served →</a>
           </p>

--- a/services/pre-purchase/index.html
+++ b/services/pre-purchase/index.html
@@ -509,7 +509,7 @@
           <a href="tel:+12508595467" class="site-nap__tel" rel="nofollow">+1‑250‑859‑5467</a>
         </div>
         <div class="site-nap__hours">
-          Hours: <time>Mon–Sun 08:00–20:00</time>
+          Hours: <time>Mon–Sat 08:00–18:00</time>
         </div>
         <p class="site-nap__coverage">
           <a href="/#coverage" class="site-nap__link">See Coverage & Areas Served →</a>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,32 +2,32 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://kelownaprotechmobilemech.com/</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://kelownaprotechmobilemech.com/services/diagnostic/</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://kelownaprotechmobilemech.com/services/pre-purchase/</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://kelownaprotechmobilemech.com/services/maintenance/</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://kelownaprotechmobilemech.com/field-reports/</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://kelownaprotechmobilemech.com/field-reports/bmw-z3-kelowna-diagnostic/</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <priority>0.6</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## Por qué
Inconsistencias de datos entre schema JSON-LD y texto visible afectan las señales E-E-A-T de Google. Posición actual: 11.7 (página 2) post Core Update marzo 2026.

## Qué se corrige
- **Horarios footer** (5 páginas): `Mon–Sun 08:00–20:00` → `Mon–Sat 08:00–18:00` — ahora coincide con el schema `OpeningHoursSpecification`
- **Conteo de reseñas** (4 páginas): `41`/`42` → `45` en texto visible — ahora coincide con `"reviewCount": "45"` en schema
- **priceRange** (`index.html`): `$$$` → `$$` en schema JSON-LD
- **sitemap.xml**: `lastmod` actualizado a `2026-04-13` en las 6 URLs (señal de frescura post Core Update)

## Resultado esperado
Datos consistentes entre schema y contenido visible → mejor evaluación E-E-A-T → recuperación de posición orgánica.

## Verificación
- [ ] Confirmar footer en cada página muestra `Mon–Sat 08:00–18:00`
- [ ] Confirmar conteo de reseñas = 45 en páginas afectadas
- [ ] Google Rich Results Test en `index.html` sin errores
- [ ] Submit sitemap en Search Console tras merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)