### PR TITLE
fix: update homepage title tag for search intent alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <link rel="icon" type="image/png" sizes="32x32" href="/Favicon.png" />
   <link rel="apple-touch-icon" sizes="180x180" href="/Favicon.png" />
-  <title>Mobile Mechanic Kelowna — Your Car Fixed, We Come to You</title>
+  <title>Mobile Mechanic Kelowna — Stranded? Fixed Today, No Tow | Protech Elite</title>
   <meta name="description" content="Car won't start? Check engine light on? Your mobile mechanic comes to you in Kelowna — same day. Real diagnosis, no tow, no shop wait. Call or text now.">
   <meta name="robots" content="index, follow" />
   <link rel="canonical" href="https://kelownaprotechmobilemech.com/" />


### PR DESCRIPTION
## Summary
- update the homepage title tag in index.html
- keep the meta description unchanged
- limit the change to a single title tag replacement

## Verification
- verified the diff only changes the homepage title line
- confirmed working tree is clean after commit