### PR TITLE
fix(seo): evergreen meta description and consistent schema

### DIFF
--- a/index.html
+++ b/index.html
@@ -737,7 +737,8 @@
   "aggregateRating": {
     "@type": "AggregateRating",
     "ratingValue": "4.9",
-    "reviewCount": "45"
+    "reviewCount": "45",
+    "bestRating": "5"
   },
   "telephone": "+1-250-859-5467",
   "address": {

--- a/our-story/index.html
+++ b/our-story/index.html
@@ -55,7 +55,7 @@
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "LocalBusiness",
+    "@type": ["AutoRepair", "LocalBusiness"],
     "@id": "https://kelownaprotechmobilemech.com/#business",
     "name": "Kelowna Protech Elite Mobile Mechanic",
     "url": "https://kelownaprotechmobilemech.com",
@@ -71,8 +71,23 @@
       "addressRegion": "BC",
       "addressCountry": "CA"
     },
-    "areaServed": ["Kelowna", "West Kelowna", "Vernon", "Lake Country", "Peachland", "Penticton", "Okanagan Valley"],
-    "openingHours": "Mo-Sa 08:00-18:00",
+    "areaServed": [
+      { "@type": "City", "name": "Kelowna" },
+      { "@type": "City", "name": "West Kelowna" },
+      { "@type": "City", "name": "Vernon" },
+      { "@type": "City", "name": "Lake Country" },
+      { "@type": "City", "name": "Peachland" },
+      { "@type": "City", "name": "Penticton" },
+      { "@type": "State", "name": "Okanagan Valley" }
+    ],
+    "openingHoursSpecification": [
+      {
+        "@type": "OpeningHoursSpecification",
+        "dayOfWeek": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
+        "opens": "08:00",
+        "closes": "18:00"
+      }
+    ],
     "aggregateRating": {
       "@type": "AggregateRating",
       "ratingValue": "4.9",

--- a/services/maintenance/index.html
+++ b/services/maintenance/index.html
@@ -16,7 +16,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/Favicon.png" />
 
     <title>Preventive Maintenance Kelowna | Mobile Mechanic</title>
-    <meta name="description" content="Spring maintenance in Kelowna — tires, brakes, fluids, and a full check before summer. Mobile service at your location, same day. 100+ completed." />
+    <meta name="description" content="Preventive maintenance in Kelowna — tires, brakes, fluids, and a full vehicle check at your location. Same-day mobile service. 100+ services completed." />
     <meta name="robots" content="index,follow">
     <link rel="canonical" href="https://kelownaprotechmobilemech.com/services/maintenance/" />
 


### PR DESCRIPTION
## Summary
- Replace seasonal meta description on `/services/maintenance/` with evergreen copy — removes "Spring maintenance... before summer" language that would become outdated in ~6 weeks
- Unify `@type` to `["AutoRepair", "LocalBusiness"]` in `our-story/index.html` schema — matches `index.html`
- Migrate `openingHours` string → `openingHoursSpecification` array in `our-story/index.html` — correct Schema.org structured format
- Convert `areaServed` to typed objects in `our-story/index.html` — consistent with `index.html`
- Add `bestRating: "5"` to `aggregateRating` in `index.html` — field was present in our-story but missing here

## Files changed
- `services/maintenance/index.html` — meta description only
- `our-story/index.html` — JSON-LD schema block only
- `index.html` — JSON-LD schema block only

## Test plan
- [ ] Verify no visible layout changes on homepage, maintenance page, and our-story page
- [ ] Confirm no console errors
- [ ] Validate schema with Google Rich Results Test after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)