### PR TITLE
Fix mobile menu overlay

### DIFF
--- a/estilos-header2.css
+++ b/estilos-header2.css
@@ -849,7 +849,17 @@ COMPONENTE: BOTÓN FLOTANTE DE LLAMADA A LA ACCIÓN (CTA) - DISEÑO PREMIUM
 @media only screen and (max-width: 767px) {
   .kpem-header-mobile {
     height: 92px;
-    overflow: hidden;
+    overflow: visible;
+    transform: none;
+  }
+
+  body.menu-is-open .kpem-header-mobile {
+    position: fixed;
+    inset: 0;
+    height: 100vh;
+    padding: 0;
+    background: #111827;
+    z-index: 10000;
   }
 
   .kpem-header-mobile .contenedor-logo {

--- a/index.html
+++ b/index.html
@@ -590,7 +590,17 @@
     @media only screen and (max-width:767px) {
       .kpem-header-mobile {
         height: 92px;
-        overflow: hidden
+        overflow: visible;
+        transform: none
+      }
+
+      body.menu-is-open .kpem-header-mobile {
+        position: fixed;
+        inset: 0;
+        height: 100vh;
+        padding: 0;
+        background: #111827;
+        z-index: 10000
       }
 
       .mobile-cta-bar {


### PR DESCRIPTION
## Summary
- Restore full-screen mobile menu overlay when hamburger opens
- Keep header from clipping the menu by changing the open state styling
- Mirror the fix in critical inline CSS and shared header CSS

## Verification
- Tested locally at http://127.0.0.1:4173/
- Confirmed hamburger opens black full-screen menu with links visible
- Confirmed close button returns to normal header