### PR TITLE
fix: update review count from 45 to 55 across all pages

### DIFF
--- a/field-reports/bmw-z3-kelowna-diagnostic/index.html
+++ b/field-reports/bmw-z3-kelowna-diagnostic/index.html
@@ -707,7 +707,7 @@
         </a>
       </div>
       <div class="badges">
-        <span>✓ 4.9★ (45 Reviews)</span>
+        <span>✓ 4.9★ (55 Reviews)</span>
         <span>✓ 15+ Years Engineering Experience</span>
         <span>✓ 100+ On-Site Diagnostics</span>
       </div>

--- a/field-reports/index.html
+++ b/field-reports/index.html
@@ -360,7 +360,7 @@
           aria-label="Text Joseph at (250) 859-5467">Text for Quote</a>
       </div>
       <div style="display:flex; gap:20px; align-items:center; justify-content:center; margin-top:28px; color:#94a3b8; font-size:13px; flex-wrap:wrap;">
-        <span>✓ 4.9★ (45 Reviews)</span>
+        <span>✓ 4.9★ (55 Reviews)</span>
         <span>✓ 15+ Years Engineering Experience</span>
         <span>✓ 100+ On-Site Diagnostics</span>
       </div>

--- a/index.html
+++ b/index.html
@@ -813,7 +813,7 @@
   "aggregateRating": {
     "@type": "AggregateRating",
     "ratingValue": "4.9",
-    "reviewCount": "45",
+    "reviewCount": "55",
     "bestRating": "5"
   },
   "telephone": "+1-250-859-5467",
@@ -914,9 +914,9 @@
   <!-- FOLD 03: Hero Section -->
   <section id="hero" class="hero-fold">
     <div class="hero-fold__content">
-      <div class="hero-fold__trust" aria-label="Trusted by 45 Google reviewers">
-        <p class="hero-fold__trust-stars" aria-label="Rated 4.9 out of 5 from 45 Google reviews">
-          ★★★★★<span class="hero-fold__trust-meta">4.9 · Trusted by 45 Google Reviews</span>
+      <div class="hero-fold__trust" aria-label="Trusted by 55 Google reviewers">
+        <p class="hero-fold__trust-stars" aria-label="Rated 4.9 out of 5 from 55 Google reviews">
+          ★★★★★<span class="hero-fold__trust-meta">4.9 · Trusted by 55 Google Reviews</span>
         </p>
         <p class="hero-fold__trust-quote">"Honest mechanic who shows you what's actually wrong." &mdash; Tyler T.</p>
       </div>

--- a/our-story/index.html
+++ b/our-story/index.html
@@ -91,7 +91,7 @@
     "aggregateRating": {
       "@type": "AggregateRating",
       "ratingValue": "4.9",
-      "reviewCount": "45",
+      "reviewCount": "55",
       "bestRating": "5"
     }
   }
@@ -237,7 +237,7 @@
 
       <p>The company runs professional-grade Autel diagnostic equipment and uses Meta smart glasses for documentation on complex repairs. It operates like what it is: an engineered diagnostic process applied to every vehicle, every time.</p>
 
-      <p>Since opening, Kelowna Protech has built a 4.9&#8209;star rating across 45 Google reviews. A lot of those reviews mention the same thing — they'd already tried somewhere else.</p>
+      <p>Since opening, Kelowna Protech has built a 4.9&#8209;star rating across 55 Google reviews. A lot of those reviews mention the same thing — they'd already tried somewhere else.</p>
 
       <p>The problems Joseph and Maricela saw in 2021 are still there across most of the market. Kelowna Protech was built specifically because they are.</p>
     </article>
@@ -246,7 +246,7 @@
     <div class="stats-bar" aria-label="Company credentials">
       <div class="stat-item">
         <span class="stat-item__value">4.9★</span>
-        <span class="stat-item__label">45 Google Reviews</span>
+        <span class="stat-item__label">55 Google Reviews</span>
       </div>
       <div class="stat-item">
         <span class="stat-item__value">15+</span>
@@ -325,7 +325,7 @@
         <a href="tel:+12508595467" class="cta-block__secondary" aria-label="Call (250) 859-5467">Call (250) 859-5467</a>
       </div>
       <div class="cta-block__trust">
-        <span>&#10003; 4.9&#9733; (45 Reviews)</span>
+        <span>&#10003; 4.9&#9733; (55 Reviews)</span>
         <span>&#10003; Certified Mechanical Engineer</span>
         <span>&#10003; Mon&ndash;Sat, 8am&ndash;6pm</span>
       </div>

--- a/services/diagnostic/index.html
+++ b/services/diagnostic/index.html
@@ -416,7 +416,7 @@
         <div class="badges">
           <span>✓ Engineering-Grade Tools</span>
           <span>✓ Same-Day Available</span>
-          <span>✓ 4.9★ (45 Reviews)</span>
+          <span>✓ 4.9★ (55 Reviews)</span>
         </div>
       </div>
       <figure>


### PR DESCRIPTION
## Summary
- Updated `reviewCount` in JSON-LD structured data (index.html, our-story/index.html)
- Updated all visible review count badges and text from 45 → 55
- Reflects current 55 Google reviews at 4.9★

## Files changed
- `index.html` — JSON-LD + 2 visible references
- `our-story/index.html` — JSON-LD + 3 visible references
- `field-reports/index.html` — 1 badge
- `field-reports/bmw-z3-kelowna-diagnostic/index.html` — 1 badge
- `services/diagnostic/index.html` — 1 badge

## Test plan
- [x] Verified locally at http://localhost:8080 — hero shows "55 Google Reviews"
- [x] No design, copy, or structure changes — numbers only
- [x] JSON-LD and visible text consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)