### PR TITLE
fix: update meta descriptions and add byline to BMW Z3 field report

### DIFF
--- a/field-reports/bmw-z3-kelowna-diagnostic/index.html
+++ b/field-reports/bmw-z3-kelowna-diagnostic/index.html
@@ -16,7 +16,7 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/Favicon.png" />
   <title>BMW Z3 Breakdown in Kelowna — Diagnosed On-Site</title>
   <meta name="description"
-    content="A red BMW Z3 broke down in a Kelowna parking lot with a coolant leak and multiple hidden issues. Joseph diagnosed the full condition on-site — no tow, no dealer, same day." />
+    content="Car breaks down in Kelowna. You need answers fast, not in two weeks. One call. We found everything wrong with this BMW Z3 — on-site, same day." />
   <meta name="robots" content="index,follow" />
   <link rel="canonical" href="https://kelownaprotechmobilemech.com/field-reports/bmw-z3-kelowna-diagnostic/" />
 
@@ -480,10 +480,11 @@
           "description": "A red BMW Z3 broke down in a Kelowna parking lot with a coolant leak and multiple hidden issues. Joseph diagnosed the full condition on-site — no tow, no dealer, same day.",
           "image": "https://kelownaprotechmobilemech.com/images/bmw-z3-kelowna-parking.jpg",
           "datePublished": "2026-01-01",
+          "dateModified": "2026-06-17",
           "author": {
-            "@type": "Person",
-            "name": "Joseph",
-            "worksFor": { "@id": "https://kelownaprotechmobilemech.com/#org" }
+            "@type": "Organization",
+            "name": "Kelowna Protech Elite Mobile Mechanic",
+            "@id": "https://kelownaprotechmobilemech.com/#org"
           },
           "publisher": { "@id": "https://kelownaprotechmobilemech.com/#org" },
           "isPartOf": { "@id": "https://kelownaprotechmobilemech.com/field-reports/bmw-z3-kelowna-diagnostic/#webpage" },
@@ -558,6 +559,7 @@
     <!-- HEADER / HERO (Centered) -->
     <header class="case-header" id="top">
       <h1>His BMW Z3 Broke Down in a Kelowna Parking Lot. He Thought It Was Just a Leak.</h1>
+      <p class="byline" style="font-size:13px;color:#64748b;margin:8px 0 0;">By <strong>Kelowna Protech Elite Mobile Mechanic</strong> · Updated June 2026</p>
 
       <div class="badge-strip" aria-label="Service highlights">
         <span>📍 Serving Kelowna &amp; Okanagan Valley</span>

--- a/our-story/index.html
+++ b/our-story/index.html
@@ -18,7 +18,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/Favicon.png" />
   <link rel="apple-touch-icon" sizes="180x180" href="/Favicon.png" />
   <title>How Kelowna Protech Was Built | Kelowna Protech Elite Mobile Mechanic</title>
-  <meta name="description" content="Joseph and Maricela founded Kelowna Protech Elite Mobile Mechanic in 2024 after years inside the Okanagan automotive industry. This is the story of why, and what they built." />
+  <meta name="description" content="We spent 15 years watching shops misdiagnose cars and charge for it. Kelowna Protech was built to fix that — real diagnosis, your driveway." />
   <meta name="robots" content="index, follow" />
   <link rel="canonical" href="https://kelownaprotechmobilemech.com/our-story/" />
 

--- a/services/pre-purchase/index.html
+++ b/services/pre-purchase/index.html
@@ -18,7 +18,7 @@
 
   <title>Pre-Purchase Inspection Kelowna — Mobile, Same Day | Kelowna Protech</title>
   <meta name="description"
-    content="Mobile pre-purchase inspection Kelowna — we go to the seller's location, same day. Photo-rich report, certified mechanic. We can also repair on-site. Book now." />
+    content="Used cars cost buyers thousands in surprise repairs every year. One inspection before you buy can save you all of it. We come to the seller. Same day." />
   <meta name="robots" content="index,follow" />
 
   <!-- Canonical sin www -->


### PR DESCRIPTION
## Summary
- `our-story`: rewritten with brand story hook — loss/fear framework, clear differentiator
- `pre-purchase`: rewritten with loss hook (surprise repair costs thousands)
- `bmw-z3`: rewritten meta + visible byline added under H1 + dateModified 2026-06-17 in JSON-LD

## Test plan
- [x] All 3 pages load correctly in local preview
- [x] All meta descriptions under 155 chars
- [x] Byline visible on BMW Z3 page below H1

🤖 Generated with [Claude Code](https://claude.com/claude-code)